### PR TITLE
Add box_url instead of box

### DIFF
--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -4,7 +4,8 @@
 Vagrant.configure("2") do |config|
 
   config.vm.define "airy-core", primary: true, autostart: true do |airy_core|
-    airy_core.vm.box = "https://s3.amazonaws.com/core-images.airy.co/vagrant/airy.box"
+    airy_core.vm.box = "airy"
+    airy_core.vm.box_url = "https://s3.amazonaws.com/core-images.airy.co/vagrant/airy.box"
     airy_core.vm.network "private_network", ip: "192.168.50.4"
     airy_core.vm.provision "user-data", type: "shell" do |s|
        s.inline = "/vagrant/scripts/user-input.sh"


### PR DESCRIPTION
Putting only
```
 airy_core.vm.box_url = "https://s3.amazonaws.com/core-images.airy.co/vagrant/airy.box"
```
didn't work
```
Bringing machine 'airy-core' up with 'virtualbox' provider...
There are errors in the configuration of this machine. Please fix
the following errors and try again:

vm:
* A box must be specified.
```

So I also needed to put 
```
airy_core.vm.box = "airy"
```