### PR TITLE
[#685] Type errors not caught by Typescript

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -6,6 +6,11 @@ load("@io_bazel_rules_go//go:def.bzl", "TOOLS_NOGO", "nogo")
 
 package(default_visibility = ["//visibility:public"])
 
+alias(
+    name = "tsconfig.json",
+    actual = "//:bazel.tsconfig.json",
+)
+
 multirun(
     name = "fix",
     commands = [
@@ -165,7 +170,6 @@ exports_files(
         ".prettierrc.json",
         ".prettierignore",
         "yarn.lock",
-        "tsconfig.json",
     ],
 )
 

--- a/bazel.tsconfig.json
+++ b/bazel.tsconfig.json
@@ -1,0 +1,51 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "strict": false,
+    "baseUrl": "./",
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "sourceMap": true,
+    "jsx": "react",
+    "paths": {
+      "components": [
+        "./frontend/components/src"
+      ],
+      "components/*": [
+        "./frontend/components/src/*"
+      ],  
+      "httpclient": [
+        "./lib/typescript/httpclient"
+      ],
+      "httpclient/*": [
+        "./lib/typescript/httpclient/*"
+      ],
+      "types": [
+        "./lib/typescript/types"
+      ],
+      "types/*": [
+        "./lib/typescript/types/*"
+      ],
+      "websocketclient": [
+        "./lib/typescript/websocketclient"
+      ],
+      "websocketclient/*": [
+        "./lib/typescript/websocketclient/*"
+      ],
+      "*": [
+        "./*"
+      ]
+    }
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/frontend/chat-plugin/BUILD
+++ b/frontend/chat-plugin/BUILD
@@ -44,8 +44,8 @@ ts_library(
 
 ts_config(
     name = "widget_tsconfig",
-    src = "tsconfig.json",
-    deps = ["//:tsconfig.json"],
+    src = "bazel.tsconfig.json",
+    deps = ["//:bazel.tsconfig.json"],
 )
 
 pkg_tar(

--- a/frontend/chat-plugin/bazel.tsconfig.json
+++ b/frontend/chat-plugin/bazel.tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../bazel.tsconfig.json",
+  "compilerOptions": {
+    "jsxFactory": "h"
+  }
+}

--- a/frontend/chat-plugin/tsconfig.json
+++ b/frontend/chat-plugin/tsconfig.json
@@ -1,6 +1,6 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "jsxFactory": "h"
-  }
+  "extends": "./bazel.tsconfig.json",
+  "include": [
+    "./src/**/*",
+  ],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,51 +1,7 @@
 {
-  "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "strict": false,
-    "baseUrl": "./",
-    "noImplicitAny": false,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "sourceMap": true,
-    "jsx": "react",
-    "paths": {
-      "components": [
-        "./frontend/components/src"
-      ],
-      "components/*": [
-        "./frontend/components/src/*"
-      ],
-      "types": [
-        "./lib/typescript/types"
-      ],
-      "types/*": [
-        "./lib/typescript/types/*"
-      ],
-      "httpclient": [
-        "./lib/typescript/httpclient"
-      ],
-      "httpclient/*": [
-        "./lib/typescript/httpclient/*"
-      ],
-      "websocketclient": [
-        "./lib/typescript/websocketclient"
-      ],
-      "websocketclient/*": [
-        "./lib/typescript/websocketclient/*"
-      ],
-      "*": [
-        "./*"
-      ]
-    }
-  },
-  "exclude": [
-    "node_modules"
-  ]
+  "extends": "./bazel.tsconfig.json",
+  "include": [
+    "./frontend/**/*",
+    "./lib/typescript/**/*",
+  ],
 }


### PR DESCRIPTION
This is the first step for the typescript issue. It aligns vs code with the typescript we use in bazel

references #685
