### PR TITLE
[#754] Specify CPUs and memory at bootstrap

### DIFF
--- a/docs/docs/getting-started/deployment/test-environment.md
+++ b/docs/docs/getting-started/deployment/test-environment.md
@@ -59,6 +59,14 @@ ${TWILIO_WEBHOOK_PUBLIC_URL}/twilio
 "curl -X POST -H 'Content-Type: application/json' -d '{\"first_name\": \"Grace\",\"last_name\": \"Hopper\",\"password\": \"the_answer_is_42\",\"email\": \"grace@example.com\"}'
 ```
 
+### Overwrite default CPUs and memory
+
+You can specify number of CPU and memory (in MB) you want to use for your Airy Core box with the following ENV variables:
+
+```sh
+AIRY_CORE_CPUS=2 AIRY_CORE_MEMORY=4096 ./scripts/bootstrap.sh
+```
+
 ### Inspect Kubernetes
 
 ```sh
@@ -78,6 +86,18 @@ vagrant halt
 vagrant up
 vagrant reload
 ```
+
+:::note
+
+If you bootstrapped your Airy Core with custom CPU/RAM values, you must specify them again when you restart your box.
+
+```sh
+cd infrastructure
+vagrant halt
+AIRY_CORE_CPUS=2 AIRY_CORE_MEMORY=4096 vagrant up
+```
+
+:::
 
 ### Re-create the environment
 

--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -1,6 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+cpus = ENV['AIRY_CORE_CPUS'] || 4
+memory = ENV['AIRY_CORE_MEMORY'] || 7168
+
 Vagrant.configure("2") do |config|
   config.vm.define "airy-core", autostart: true do |airy_core|
     airy_core.vm.box = "generic/alpine310"
@@ -9,8 +12,8 @@ Vagrant.configure("2") do |config|
     airy_core.vm.network "private_network", ip: "192.168.50.5"
     config.hostsupdater.aliases = %w[chatplugin.airy demo.airy api.airy]
     airy_core.vm.provider "virtualbox" do |vbox|
-      vbox.cpus = 4
-      vbox.memory = 7168
+      vbox.cpus = cpus
+      vbox.memory = memory
       vbox.customize [ "modifyvm", :id, "--audio", "none" ]
     end
     airy_core.vm.synced_folder "./", "/vagrant", disabled: false

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -143,9 +143,7 @@ if [[ ${NGROK_ENABLED} != "false" ]]; then
     NGROK_ENABLED="true"
 fi
 
-echo ngrok: ${NGROK_ENABLED}
-
-AIRY_VERSION=${AIRY_VERSION} NGROK_ENABLED=${NGROK_ENABLED} vagrant up
+AIRY_VERSION=${AIRY_VERSION} NGROK_ENABLED=${NGROK_ENABLED} AIRY_CORE_CPUS=${AIRY_CORE_CPUS} AIRY_CORE_MEMORY=${AIRY_CORE_MEMORY} vagrant up
 
 mkdir -p ~/.airy
 cd $infra_path


### PR DESCRIPTION
Usage:
```
AIRY_CORE_CPUS=2 AIRY_CORE_MEMORY=4096 ./scripts/bootstrap.sh
```

Note that if one does `vagrant halt` and then `vagrant up` without specifying the values, then when the machine is started, cpu and memory will be set to the default values. Added that to the docs.