### PR TITLE
[#722] Add AKHQ as optional tool

### DIFF
--- a/infrastructure/airy.tpl.yaml
+++ b/infrastructure/airy.tpl.yaml
@@ -5,7 +5,7 @@ global:
   namespace: default
   ingress:
     apiHost: api.airy
-    webhooksHost: "webhooks.airy"
+    webhooksHost: webhooks.airy
     uiHost: ui.airy
     chatpluginHost: chatplugin.airy
 prerequisites:
@@ -56,3 +56,6 @@ apps:
         bucket: "changeme"
         region: "changeme"
         path: "path"
+tools:
+  akhq:
+    enabled: false

--- a/infrastructure/helm-chart/charts/tools/Chart.yaml
+++ b/infrastructure/helm-chart/charts/tools/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Optional tools for the Airy Core Platform
+name: tools
+version: 1.0

--- a/infrastructure/helm-chart/charts/tools/charts/ahkq/Chart.yaml
+++ b/infrastructure/helm-chart/charts/tools/charts/ahkq/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: AKHQ tool for Apache Kafka
+name: akhq
+version: 1.0

--- a/infrastructure/helm-chart/charts/tools/charts/ahkq/templates/configmap.yaml
+++ b/infrastructure/helm-chart/charts/tools/charts/ahkq/templates/configmap.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.enabled }}
+{{- $password := (randAlphaNum 10 | lower) }}
+kind: ConfigMap 
+apiVersion: v1 
+metadata:
+  name: akhq-config
+data:  
+  password: {{ $password }}
+  application.yml: | 
+    akhq:
+      server:
+        access-log:
+          enabled: true
+          format: "[Date: {}] [Duration: {} ms] [Url: {} {}] [Status: {}] [Ip: {}] [User: {}]"
+      clients-defaults:
+        consumer:
+          properties:
+            isolation.level: read_committed
+      connections:
+        core:
+          properties:
+            bootstrap.servers: ${KAFKA_BROKERS}
+          schema-registry:
+            url: ${KAFKA_SCHEMA_REGISTRY_URL}
+      pagination:
+        page-size: 25
+        threads: 16
+      # Topic list display options (optional)
+      topic:
+        retention: 172800000
+        partition: 3
+        replication: 3
+        default-view: HIDE_INTERNAL
+        internal-regexps:
+          - "^_.*$"
+          - "^.*_schemas$"
+          - "^.*connect-config$"
+          - "^.*connect-offsets$1"
+          - "^.*connect-status$"
+        stream-regexps:
+          - "^.*-changelog$"
+          - "^.*-repartition$"
+          - "^.*-rekey$"
+        skip-consumer-groups: false
+      # Topic display data options (optional)
+      topic-data:
+        sort: OLDEST # default sort order (OLDEST, NEWEST) (default: OLDEST)
+        size: 50 # max record per page (default: 50)
+        poll-timeout: 1000 # The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
+      security:
+        default-group: no-roles
+        basic-auth:
+          - username: admin
+            password: {{ sha256sum $password }}
+            groups:
+              - admin
+    micronaut:
+      security:
+        enabled: true
+        token:
+          jwt:
+            signatures:
+              secret:
+                generator:
+                  secret: {{ randAlphaNum 128 | quote }}
+{{- end }}

--- a/infrastructure/helm-chart/charts/tools/charts/ahkq/templates/deployment.yaml
+++ b/infrastructure/helm-chart/charts/tools/charts/ahkq/templates/deployment.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: akhq
+  namespace: "default"
+  labels:
+    app: akhq
+    type: enterprise
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: akhq
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: akhq
+    spec:
+      containers:
+        - name: app
+          image: tchiotludo/akhq:0.16.0 
+          imagePullPolicy: Always
+          volumeMounts:
+          - name: akhq-config
+            mountPath: /app/application.yml
+            subPath: application.yml
+          env:
+            - name: KAFKA_BROKERS
+              valueFrom:
+                configMapKeyRef:
+                  name: kafka-config
+                  key: KAFKA_BROKERS
+            - name: KAFKA_SCHEMA_REGISTRY_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: kafka-config
+                  key: KAFKA_SCHEMA_REGISTRY_URL
+            - name: SERVICE_NAME
+              value: akhq
+      volumes:
+        - name: akhq-config
+          configMap:
+            name: akhq-config
+  {{ end }}

--- a/infrastructure/helm-chart/charts/tools/charts/ahkq/templates/ingress.yaml
+++ b/infrastructure/helm-chart/charts/tools/charts/ahkq/templates/ingress.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: akhq
+type: Opaque
+data:
+  auth: YWlyeTokYXByMSRZR3E3b0dFRyRuSEoxWVl6dGxVanY5R253OWprVGYxCg==
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: akhq
+  namespace: {{ .Values.global.namespace }}
+spec:
+  rules:
+    - host: akhq.{{ .Values.global.ingress.toolsHost }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: akhq
+                port:
+                  number: 8080
+{{- end }}

--- a/infrastructure/helm-chart/charts/tools/charts/ahkq/templates/service.yaml
+++ b/infrastructure/helm-chart/charts/tools/charts/ahkq/templates/service.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: akhq 
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort
+  selector:
+    app: akhq
+{{- end }}

--- a/infrastructure/helm-chart/charts/tools/charts/ahkq/values.yaml
+++ b/infrastructure/helm-chart/charts/tools/charts/ahkq/values.yaml
@@ -1,0 +1,1 @@
+enabled: false

--- a/infrastructure/helm-chart/values.yaml
+++ b/infrastructure/helm-chart/values.yaml
@@ -8,3 +8,4 @@ global:
     webhooksHost: "webhooks.airy"
     uiHost: "ui.airy"
     chatpluginHost: "chatplugin.airy"
+    toolsHost: "tools.airy"


### PR DESCRIPTION
AKHQ is deployed if `tools.akhq.enabled=true` in the `airy.yaml` file.
Basic authentication is enabled. Default username is `admin`. The password can be retrieved from a configMap:
```
kubectl get configmap akhq-config -o jsonpath="{.data.password}"
```