### PR TITLE
Fix Netlify docs previews

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -2,7 +2,7 @@ module.exports = {
   title: 'Airy Documentation',
   tagline: 'Airy documentation website',
   url: 'https://airy.co',
-  baseUrl: '/docs/core/',
+  baseUrl: process.env.CONTEXT === 'production' ? '/docs/core/' : '/',
   onBrokenLinks: 'throw',
   favicon: 'img/favicon.ico',
   organizationName: 'airyhq',


### PR DESCRIPTION
Currently `develop.docs.airy.co` and the branch previews do not work, because they docusaurus build has a static `baseUrl` set to `/docs/core`