### PR TITLE
[#957] Add ErrorBoundaries for the RenderLibrary

### DIFF
--- a/lib/typescript/render/index.tsx
+++ b/lib/typescript/render/index.tsx
@@ -6,13 +6,39 @@ import {getDefaultMessageRenderingProps, MessageRenderProps} from './shared';
 
 export * from './shared';
 
-export const SourceMessage = (props: MessageRenderProps) => {
-  const provider = renderProviders[props.source];
-
-  try {
-    return provider(props);
-  } catch (e) {
-    console.error(e);
-    return <Text {...getDefaultMessageRenderingProps(props)} text="Could not render this content" />;
-  }
+type SourceMessageState = {
+  hasError: boolean;
 };
+
+export class SourceMessage extends React.Component<MessageRenderProps, SourceMessageState> {
+  constructor(props: MessageRenderProps) {
+    super(props);
+    this.state = {hasError: false};
+  }
+
+  static getDerivedStateFromError() {
+    return {hasError: true};
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error(error, errorInfo);
+  }
+
+  errorFallback() {
+    return <Text {...getDefaultMessageRenderingProps(this.props)} text="Could not render this content" />;
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.errorFallback();
+    }
+    const provider = renderProviders[this.props.source];
+
+    try {
+      return provider(this.props);
+    } catch (e) {
+      console.error(e);
+      return this.errorFallback();
+    }
+  }
+}


### PR DESCRIPTION
Sadly I found cases where the try..catch failed. And it was not possible
to catch them  with the hooks approach. I needed to transform this to a
Component. See also [this faq](https://reactjs.org/docs/hooks-faq.html#do-hooks-cover-all-use-cases-for-classes).

closes #957
