### PR TITLE
[#1310] Airy CLI sha changes after the release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,17 +55,9 @@ jobs:
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       - name: Upload airy binary to S3
-        if: startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/main')
+        if: ${{ github.ref == 'refs/heads/develop') }} || startsWith(github.ref, 'refs/heads/release') || ${{ github.ref == 'refs/heads/main'}}
         run: |
-          ./scripts/upload-cli-binaries.sh
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - name: Upload airy binary to S3 [develop]
-        if: startsWith(github.ref, 'refs/heads/develop')
-        run: |
-          aws s3 cp bazel-bin/cli/airy_linux_bin s3://airy-core-binaries/develop/linux/amd64/airy
-          aws s3 cp bazel-bin/cli/airy_darwin_bin s3://airy-core-binaries/develop/darwin/amd64/airy
+          ./scripts/upload-cli-binaries.sh ${GITHUB_REF##*/}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       - name: Upload airy binary to S3
-        if: ${{ github.ref == 'refs/heads/develop') }} || startsWith(github.ref, 'refs/heads/release') || ${{ github.ref == 'refs/heads/main'}}
+        if: ${{ github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release') || github.ref == 'refs/heads/main' }}
         run: |
           ./scripts/upload-cli-binaries.sh ${GITHUB_REF##*/}
         env:

--- a/docs/docs/concepts/release-process.md
+++ b/docs/docs/concepts/release-process.md
@@ -26,7 +26,9 @@ Once a release day comes, we execute the following steps:
   - You must wait for all the images to be pushed via CI.
 - Once we're satisfied with the release, we publish the release:
   - We run `./scripts/release.sh finish x.y.z`
-  - We update the version string and the sha in the [Homebrew Formula](https://github.com/airyhq/homebrew-airy/blob/main/Formula/cli.rb) for the CLI.
+  - We update the version string to `x.y.z` and the sha to `https://airy-core-binaries.s3.amazonaws.com/x.y.z/darwin/amd64/airy_darwin_sha256sum.txt` in the [Homebrew
+    Formula](https://github.com/airyhq/homebrew-airy/blob/main/Formula/cli.rb)
+    for the CLI.
   - We archive cards in the done column of the [work in progress](https://github.com/airyhq/airy/projects/1) board
   - We tag the draft release with the tag `x.y.z` and publish it.
   - We announce the release!

--- a/scripts/upload-cli-binaries.sh
+++ b/scripts/upload-cli-binaries.sh
@@ -2,17 +2,31 @@
 set -eo pipefail
 IFS=$'\n\t'
 
-for os in "linux" "darwin" "windows"
-do
-    sha256sum bazel-bin/cli/airy_"$os"_bin > bazel-bin/cli/airy_"$os"_sha256sum.txt
-    if [[ ${os} = "windows" ]]
-    then
-        aws s3 cp bazel-bin/cli/airy_"$os"_bin s3://airy-core-binaries/"$(cat ./VERSION)"/"$os"/amd64/airy.exe
-    else
-        aws s3 cp bazel-bin/cli/airy_"$os"_bin s3://airy-core-binaries/"$(cat ./VERSION)"/"$os"/amd64/airy
-    fi
-    aws s3 cp bazel-bin/cli/airy_"$os"_sha256sum.txt s3://airy-core-binaries/"$(cat ./VERSION)"/"$os"/amd64/
+branch=$1
+arch="amd64"
+bucket_name="airy-core-binaries"
+version=$(cat ./VERSION)
+
+for os in "linux" "darwin" "windows"; do
+    airy_bin_path=bazel-bin/cli/airy_"$os"_bin
+    airy_bin_sha_path=bazel-bin/cli/airy_"$os"_sha256sum.txt
+    if [[ ${os} = "windows" ]]; then filename="airy.exe"; else filename="airy"; fi
+
+    case $branch in
+    develop)
+        s3_basepath="s3://$bucket_name/develop/$os/$arch"
+        ;;
+    release*)
+        s3_basepath="s3://$bucket_name/$version-rc/$os/$arch"
+        ;;
+    main)
+        s3_basepath="s3://$bucket_name/$version/$os/$arch"
+        ;;
+    esac
+
+    sha256sum $airy_bin_path >$airy_bin_sha_path
+    aws s3 cp $airy_bin_path "$s3_basepath/$filename"
+    aws s3 cp $airy_bin_sha_path "$s3_basepath/"
 done
 
-cat ./VERSION > stable.txt
-aws s3 cp stable.txt s3://airy-core-binaries/stable.txt
+aws s3 cp ./VERSION s3://$bucket_name/stable.txt

--- a/scripts/upload-cli-binaries.sh
+++ b/scripts/upload-cli-binaries.sh
@@ -29,4 +29,4 @@ for os in "linux" "darwin" "windows"; do
     aws s3 cp $airy_bin_sha_path "$s3_basepath/"
 done
 
-aws s3 cp ./VERSION s3://$bucket_name/stable.txt
+aws s3 cp VERSION s3://$bucket_name/stable.txt


### PR DESCRIPTION
I think that should solve it. I at least remember one instance where I accidentally pushed to the release branch after the release and that caused the last commit sha to change and therefore the sha of the cli binary