### PR TITLE
added showmode flag that blocks functionality in chat plugin

### DIFF
--- a/frontend/chat-plugin/src/App.tsx
+++ b/frontend/chat-plugin/src/App.tsx
@@ -40,6 +40,7 @@ export type Config = {
   accentColor?: string;
   bubbleIcon?: string;
   sendMessageIcon?: string;
+  showMode: boolean;
 };
 
 export const config: Config = {
@@ -70,4 +71,5 @@ export const config: Config = {
       },
     },
   },
+  showMode: false,
 };

--- a/frontend/chat-plugin/src/components/chat/index.tsx
+++ b/frontend/chat-plugin/src/components/chat/index.tsx
@@ -48,6 +48,8 @@ const Chat = (props: Props) => {
   const [connectionState, setConnectionState] = useState(null);
 
   useEffect(() => {
+    if (config.showMode) return;
+
     ws = new WebSocket(props.channelId, onReceive, setInitialMessages, (state: ConnectionState) => {
       setConnectionState(state);
     });
@@ -90,6 +92,7 @@ const Chat = (props: Props) => {
   };
 
   const sendMessage = (text: string) => {
+    if (config.showMode) return;
     ctrl.sendMessage(text);
   };
 


### PR DESCRIPTION
closes #1474 

- showMode flag added in Chat Plugin's config 
- when set to true, showMode disables the chat's functionality (default is false)