### PR TITLE
added conversation count in inbox

### DIFF
--- a/frontend/ui/src/pages/Inbox/ConversationListHeader/index.tsx
+++ b/frontend/ui/src/pages/Inbox/ConversationListHeader/index.tsx
@@ -5,6 +5,7 @@ import {SearchField} from 'components';
 import {StateModel} from '../../../reducers';
 
 import {setSearch, resetFilteredConversationAction} from '../../../actions/conversationsFilter';
+import {allConversations} from '../../../selectors/conversations';
 
 import {ReactComponent as IconSearch} from 'assets/images/icons/search.svg';
 import {ReactComponent as BackIcon} from 'assets/images/icons/arrow-left-2.svg';
@@ -17,6 +18,7 @@ const mapStateToProps = (state: StateModel) => {
   return {
     user: state.data.user,
     currentFilter: state.data.conversations.filtered.currentFilter || {},
+    conversations: allConversations(state),
   };
 };
 
@@ -59,6 +61,12 @@ const ConversationListHeader = (props: ConnectedProps<typeof connector>) => {
     handleSearch(value);
   };
 
+  const InboxConversationCount = () => {
+    const {conversations} = props;
+
+    return <div className={styles.headline}>{`Inbox (${conversations.length})`}</div>;
+  };
+
   const renderSearchInput = isShowingSearchInput ? (
     <div className={styles.containerSearchField}>
       <button type="button" className={styles.backButton} onClick={onClickBack} data-cy={cySearchFieldBackButton}>
@@ -77,7 +85,7 @@ const ConversationListHeader = (props: ConnectedProps<typeof connector>) => {
     </div>
   ) : (
     <div className={styles.containerSearchHeadline}>
-      <div className={styles.headline}>Inbox</div>
+      <InboxConversationCount />
       <div className={styles.searchBox} data-cy={cySearchButton}>
         <button type="button" className={styles.searchButton} onClick={onClickSearch}>
           <IconSearch className={styles.searchIcon} title="Search" />

--- a/frontend/ui/src/pages/Inbox/ConversationsFilter/index.tsx
+++ b/frontend/ui/src/pages/Inbox/ConversationsFilter/index.tsx
@@ -17,7 +17,6 @@ const mapStateToProps = (state: StateModel) => {
   return {
     conversationsFilter: state.data.conversations.filtered.currentFilter,
     isFilterActive: isFilterActive(state),
-    conversationsPaginationData: state.data.conversations.all.paginationData,
     filteredPaginationData: state.data.conversations.filtered.paginationData,
     conversations: allConversations(state),
   };
@@ -108,8 +107,7 @@ const ConversationsFilter = (props: ConversationsFilterProps) => {
   };
 
   const itemsCount = () => {
-    const {conversationsPaginationData, filteredPaginationData} = props;
-    const formatter = new Intl.NumberFormat('en-US');
+    const {filteredPaginationData} = props;
 
     if (
       filteredPaginationData.filteredTotal !== undefined &&
@@ -118,14 +116,6 @@ const ConversationsFilter = (props: ConversationsFilterProps) => {
       return (
         <div className={styles.filterCount}>
           {`Filtered: ${filteredPaginationData.filteredTotal} Total: ${props.conversations.length}`}
-        </div>
-      );
-    }
-
-    if (conversationsPaginationData.total) {
-      return (
-        <div className={styles.filterCount}>
-          {`${formatter.format(filteredPaginationData.filteredTotal || props.conversations.length)} Conversations`}
         </div>
       );
     }


### PR DESCRIPTION
closes #1526 

changes: 
- displays conversation count next to 'Inbox'
- the count always displays the total number of conversations (even if the conversations are filtered)

<img width="1424" alt="Screenshot 2021-04-16 at 18 24 18" src="https://user-images.githubusercontent.com/38159391/115200063-1f264c00-a0f4-11eb-89ca-d3e13f582ce9.png">

<img width="1434" alt="Screenshot 2021-04-16 at 18 24 32" src="https://user-images.githubusercontent.com/38159391/115200048-1c2b5b80-a0f4-11eb-8cf2-af02e5b6174c.png">
