### PR TITLE
[#1557] fixed color picker for chat plugin customization

### DIFF
--- a/frontend/ui/src/pages/Channels/Providers/Airy/ChatPlugin/sections/CustomiseSection.tsx
+++ b/frontend/ui/src/pages/Channels/Providers/Airy/ChatPlugin/sections/CustomiseSection.tsx
@@ -229,17 +229,18 @@ export const CustomiseSection = ({channelId, host}: CustomiseSectionProps) => {
           />
         </div>
         <p>Accent Color</p>
-        {showAccentColorPicker && (
-          <ListenOutsideClick className={styles.colorPickerWrapper} onOuterClick={toggleShowAccentColorPicker}>
-            <SketchPicker
-              color={accentColor}
-              onChangeComplete={(color: {hex: string}) => {
-                setAccentColor(color.hex.toUpperCase());
-              }}
-            />
-          </ListenOutsideClick>
-        )}
         <div className={styles.colorPicker}>
+          {showAccentColorPicker && (
+            <ListenOutsideClick className={styles.colorPickerWrapper} onOuterClick={toggleShowAccentColorPicker}>
+              <SketchPicker
+                color={accentColor}
+                onChangeComplete={(color: {hex: string}) => {
+                  setAccentColor(color.hex.toUpperCase());
+                }}
+              />
+            </ListenOutsideClick>
+          )}
+
           <div
             className={styles.colorPickerSample}
             style={{backgroundColor: accentColor}}
@@ -267,17 +268,17 @@ export const CustomiseSection = ({channelId, host}: CustomiseSectionProps) => {
           />
         </div>
         <p>Background Color</p>
-        {showBackgroundColorPicker && (
-          <ListenOutsideClick className={styles.colorPickerWrapper} onOuterClick={toggleShowBackgroundColorPicker}>
-            <SketchPicker
-              color={backgroundColor}
-              onChangeComplete={(color: {hex: string}) => {
-                setBackgroundColor(color.hex.toUpperCase());
-              }}
-            />
-          </ListenOutsideClick>
-        )}
         <div className={styles.colorPicker}>
+          {showBackgroundColorPicker && (
+            <ListenOutsideClick className={styles.colorPickerWrapper} onOuterClick={toggleShowBackgroundColorPicker}>
+              <SketchPicker
+                color={backgroundColor}
+                onChangeComplete={(color: {hex: string}) => {
+                  setBackgroundColor(color.hex.toUpperCase());
+                }}
+              />
+            </ListenOutsideClick>
+          )}
           <div
             className={styles.colorPickerSample}
             style={{backgroundColor: backgroundColor}}


### PR DESCRIPTION
closes #1557 

change: 
- the color picker for Accent and Background Color was not appearing at the right place 

before 
<img width="1436" alt="Screenshot 2021-04-15 at 13 29 34" src="https://user-images.githubusercontent.com/38159391/115408081-def8c380-a1f0-11eb-899c-81a3241b7ad6.png">



after
<img width="1431" alt="Screenshot 2021-04-20 at 15 46 32" src="https://user-images.githubusercontent.com/38159391/115407388-43675300-a1f0-11eb-81ac-1d279d9fb41c.png">
