### PR TITLE
[#1606] Conversation count on the title of the page

### DIFF
--- a/frontend/ui/src/pages/Inbox/index.tsx
+++ b/frontend/ui/src/pages/Inbox/index.tsx
@@ -10,6 +10,8 @@ import {StateModel} from '../../reducers';
 import Messenger from './Messenger';
 import {setPageTitle} from '../../services/pageTitle';
 
+import {allConversations} from '../../selectors/conversations';
+
 export type ConversationRouteProps = RouteComponentProps<{conversationId: string}>;
 
 interface InboxProps {
@@ -19,6 +21,7 @@ interface InboxProps {
 const mapStateToProps = (state: StateModel) => {
   return {
     user: state.data.user,
+    conversations: allConversations(state),
   };
 };
 
@@ -30,11 +33,16 @@ const mapDispatchToProps = {
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
 const ConversationContainer = (props: InboxProps & ConnectedProps<typeof connector>) => {
+  const {conversations, listChannels, listConversations} = props;
+
   useEffect(() => {
-    props.listConversations();
-    props.listChannels();
-    setPageTitle('Inbox');
+    listConversations();
+    listChannels();
   }, []);
+
+  useEffect(() => {
+    setPageTitle(`Inbox (${conversations.length})`);
+  }, [conversations]);
 
   return <Messenger />;
 };


### PR DESCRIPTION
closes #1606 

--> the ticket was updated: we are displaying the total number of conversations (and not the unread count)

---> the count appears on the page title when the user is on the Inbox page and updates in real time

<img width="346" alt="Screenshot 2021-04-23 at 16 57 16" src="https://user-images.githubusercontent.com/38159391/115891224-203ddd00-a456-11eb-8db9-47c1b76b7f19.png">

<img width="1438" alt="Screenshot 2021-04-23 at 16 57 16" src="https://user-images.githubusercontent.com/38159391/115890834-ab6aa300-a455-11eb-86ef-00b3ea232f43.png">
