### PR TITLE
[#1652] Fix rendering messages with render library

### DIFF
--- a/lib/typescript/render/providers/google/GoogleRender.tsx
+++ b/lib/typescript/render/providers/google/GoogleRender.tsx
@@ -51,7 +51,7 @@ function render(content: ContentUnion, props: RenderPropsUnion) {
 }
 
 function googleInbound(message: Message): ContentUnion {
-  const messageJson = message.content.message;
+  const messageJson = message.content.message ?? message.content;
 
   if (messageJson.richCard?.standaloneCard) {
     const {
@@ -128,6 +128,8 @@ function googleInbound(message: Message): ContentUnion {
 function googleOutbound(message: Message): ContentUnion {
   const messageJson = message.content.message ?? message.content;
   const maxNumberOfSuggestions = 13;
+
+  console.log('message OUTBOUND', message);
 
   if (messageJson.richCard?.standaloneCard) {
     const {

--- a/lib/typescript/render/providers/google/GoogleRender.tsx
+++ b/lib/typescript/render/providers/google/GoogleRender.tsx
@@ -129,8 +129,6 @@ function googleOutbound(message: Message): ContentUnion {
   const messageJson = message.content.message ?? message.content;
   const maxNumberOfSuggestions = 13;
 
-  console.log('message OUTBOUND', message);
-
   if (messageJson.richCard?.standaloneCard) {
     const {
       richCard: {


### PR DESCRIPTION
closes #1652 

- the Inbound Suggestion Response messages from Google caused errors so couldn't be rendered because they are not nested in a `message` object 