### PR TITLE
[#1646] fix avatar images styling

### DIFF
--- a/lib/typescript/render/components/Avatar/index.module.scss
+++ b/lib/typescript/render/components/Avatar/index.module.scss
@@ -1,13 +1,9 @@
 @import 'assets/scss/fonts.scss';
 @import 'assets/scss/colors.scss';
 
-.avatar {
-  display: flex;
-  flex-shrink: 0;
-}
-
 .avatarImage {
   border-radius: 50%;
   width: 100%;
   height: 100%;
+  object-fit: cover;
 }

--- a/lib/typescript/render/components/Avatar/index.tsx
+++ b/lib/typescript/render/components/Avatar/index.tsx
@@ -14,12 +14,10 @@ const fallbackAvatarImage = (event: SyntheticEvent<HTMLImageElement, Event>) => 
 };
 
 export const Avatar = ({contact}: AvatarProps) => (
-  <div className={styles.avatar}>
-    <img
-      alt={contact?.displayName || 'Unknown contact'}
-      className={styles.avatarImage}
-      src={contact?.avatarUrl || fallbackAvatar}
-      onError={(event: React.SyntheticEvent<HTMLImageElement, Event>) => fallbackAvatarImage(event)}
-    />
-  </div>
+  <img
+    alt={contact?.displayName || 'Unknown contact'}
+    className={styles.avatarImage}
+    src={contact?.avatarUrl || fallbackAvatar}
+    onError={(event: React.SyntheticEvent<HTMLImageElement, Event>) => fallbackAvatarImage(event)}
+  />
 );


### PR DESCRIPTION
closes #1646 --> follow-up: flickering images #1679

before 
<img width="331" alt="Screenshot 2021-04-29 at 13 55 44" src="https://user-images.githubusercontent.com/38159391/116554577-a4331180-a8fb-11eb-9567-f47867925e4b.png">


after
<img width="334" alt="Screenshot 2021-04-29 at 13 55 11" src="https://user-images.githubusercontent.com/38159391/116554594-aa28f280-a8fb-11eb-85f0-e3f522560a99.png">


