### PR TITLE
[#1689] Bug: Conversation Counter: Optimize Filter Use

### DIFF
--- a/frontend/ui/src/pages/Inbox/ConversationListHeader/index.tsx
+++ b/frontend/ui/src/pages/Inbox/ConversationListHeader/index.tsx
@@ -25,6 +25,7 @@ const mapStateToProps = (state: StateModel) => ({
   user: state.data.user,
   currentFilter: state.data.conversations.filtered.currentFilter || {},
   totalConversations: state.data.conversations.all.paginationData.total,
+  filteredPaginationData: state.data.conversations.filtered.paginationData,
 });
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
@@ -68,9 +69,11 @@ const ConversationListHeader = (props: ConversationListHeaderProps) => {
   };
 
   const InboxConversationCount = () => {
-    const {totalConversations} = props;
+    const {totalConversations, filteredPaginationData} = props;
 
-    return <div className={styles.headline}>{`Inbox (${totalConversations})`}</div>;
+    return (
+      <div className={styles.headline}>{`Inbox (${filteredPaginationData.filteredTotal ?? totalConversations})`}</div>
+    );
   };
 
   const toggleFilter = () => {

--- a/frontend/ui/src/pages/Inbox/ConversationsFilter/index.tsx
+++ b/frontend/ui/src/pages/Inbox/ConversationsFilter/index.tsx
@@ -13,7 +13,6 @@ const mapStateToProps = (state: StateModel) => {
   return {
     conversationsFilter: state.data.conversations.filtered.currentFilter,
     isFilterActive: isFilterActive(state),
-    filteredPaginationData: state.data.conversations.filtered.paginationData,
     conversations: allConversations(state),
   };
 };
@@ -33,7 +32,6 @@ const ConversationsFilter = (props: ConversationsFilterProps) => {
   const closedButton = useRef(null);
 
   useEffect(() => {
-    itemsCount();
     currentStateFilter();
   }),
     [props.conversations];
@@ -58,26 +56,8 @@ const ConversationsFilter = (props: ConversationsFilterProps) => {
     setFilter(newFilter);
   };
 
-  const itemsCount = () => {
-    const {filteredPaginationData} = props;
-
-    if (
-      filteredPaginationData.filteredTotal !== undefined &&
-      filteredPaginationData.filteredTotal !== filteredPaginationData.total
-    ) {
-      return (
-        <div className={styles.filterCount}>
-          {`Filtered: ${filteredPaginationData.filteredTotal} Total: ${props.conversations.length}`}
-        </div>
-      );
-    }
-
-    return <div className={styles.filterCount}>&nbsp;</div>;
-  };
-
   return (
     <div>
-      {itemsCount()}
       <div className={styles.quickFilterContainer}>
         <div className={styles.quickFilterButtons}>
           <div className={styles.quickFilterButtonsBackground}>


### PR DESCRIPTION
closes #1689 

- “Filtered: 34 Total: 235”  is removed 

-  the number in the parenthesis next to 'Inbox' indicates how many conversations you’re looking at: if there are no filters, it counts all conversations, and if you have a filter on, it only displays the count of conversations included in that filter
