### PR TITLE
[#1695] Twilio SMS does not display the channelSourceId correctly

### DIFF
--- a/frontend/ui/src/components/IconChannel/index.tsx
+++ b/frontend/ui/src/components/IconChannel/index.tsx
@@ -76,11 +76,15 @@ const IconChannel: React.FC<IconChannelProps> = ({
   const fbFallback = SOURCE_INFO['facebook'];
   const isFromTwilioSource = channel.source === 'twilio.sms' || channel.source === 'twilio.whatsapp';
 
+  const ChannelName = () => {
+    return <p>{channel.metadata?.name || (isFromTwilioSource ? channel.sourceChannelId : channel.source)}</p>;
+  };
+
   if (icon && showName) {
     return (
       <div className={styles.iconName}>
         {channelInfo.icon()}
-        <p>{channel.metadata?.name}</p>
+        <ChannelName />
       </div>
     );
   }
@@ -89,7 +93,7 @@ const IconChannel: React.FC<IconChannelProps> = ({
     return (
       <div className={styles.avatarName}>
         {channelInfo.avatar()}
-        <p>{channel.metadata?.name || (isFromTwilioSource ? channel.sourceChannelId : channel.source)}</p>
+        <ChannelName />
       </div>
     );
   }

--- a/frontend/ui/src/components/IconChannel/index.tsx
+++ b/frontend/ui/src/components/IconChannel/index.tsx
@@ -74,6 +74,7 @@ const IconChannel: React.FC<IconChannelProps> = ({
 
   const channelInfo = SOURCE_INFO[channel.source];
   const fbFallback = SOURCE_INFO['facebook'];
+  const isFromTwilioSource = channel.source === 'twilio.sms' || channel.source === 'twilio.whatsapp';
 
   if (icon && showName) {
     return (
@@ -88,7 +89,7 @@ const IconChannel: React.FC<IconChannelProps> = ({
     return (
       <div className={styles.avatarName}>
         {channelInfo.avatar()}
-        <p>{channel.metadata?.name}</p>
+        <p>{channel.metadata?.name || (isFromTwilioSource ? channel.sourceChannelId : channel.source)}</p>
       </div>
     );
   }

--- a/frontend/ui/src/pages/Channels/ConnectedChannelsBySourceCard/index.tsx
+++ b/frontend/ui/src/pages/Channels/ConnectedChannelsBySourceCard/index.tsx
@@ -36,7 +36,12 @@ const ConnectedChannelsBySourceCard = (props: ConnectedChannelsBySourceCardProps
                     <li key={channel.sourceChannelId} className={styles.channelListEntry}>
                       <button className={styles.connectedChannelData}>
                         <ChannelAvatar channel={channel} style={{width: '20px', height: '20px', marginRight: '4px'}} />
-                        <div className={styles.connectedChannelName}>{channel.metadata?.name}</div>
+                        <div className={styles.connectedChannelName}>
+                          {channel.metadata?.name ||
+                            (channel.source !== 'twilio.sms' && channel.source !== 'twilio.whatsapp'
+                              ? channel.source
+                              : '')}
+                        </div>
                         {sourceInfo.channelsToShow === 2 && (
                           <div className={styles.extraPhoneInfo}>{channel.sourceChannelId}</div>
                         )}


### PR DESCRIPTION
closes #1695

- if the channel does not have a name, we want to display the channel source (for channels that are not from a Twilio source), or the phone number for Twilio sources 