### PR TITLE
[#1726] Customize Start a New Conversation button

### DIFF
--- a/frontend/chat-plugin/src/components/chat/index.tsx
+++ b/frontend/chat-plugin/src/components/chat/index.tsx
@@ -190,7 +190,7 @@ const Chat = (props: Props) => {
         ) : (
           <NewConversation
             reAuthenticate={reAuthenticate}
-            startConversationText={config.startConversationText || null}
+            startNewConversationText={config.startNewConversationText || null}
           />
         );
 

--- a/frontend/chat-plugin/src/components/chat/index.tsx
+++ b/frontend/chat-plugin/src/components/chat/index.tsx
@@ -188,7 +188,10 @@ const Chat = (props: Props) => {
             setNewConversation={setNewConversation}
           />
         ) : (
-          <NewConversation reAuthenticate={reAuthenticate} />
+          <NewConversation
+            reAuthenticate={reAuthenticate}
+            startConversationText={config.startConversationText || null}
+          />
         );
 
   const bubble = props.bubbleProp

--- a/frontend/chat-plugin/src/components/newConversation/index.module.scss
+++ b/frontend/chat-plugin/src/components/newConversation/index.module.scss
@@ -5,7 +5,6 @@
 .newConversation {
   display: flex;
   justify-content: center;
-  padding-left: 20px;
   margin: 0;
   font-family: 'Lato', sans-serif;
   color: var(--color-airy-blue);
@@ -19,12 +18,32 @@
   margin: 0;
 }
 
-.newConversationLink {
+.startConversationContainer {
   display: flex;
   justify-content: center;
+  width: 100%;
   margin-bottom: 20px;
+}
+
+.newConversationLink,
+.newConversationLink:hover,
+.newConversationLink:active {
+  text-decoration: none;
+  color: var(--color-airy-blue);
   font-family: 'Lato', sans-serif;
+  font-size: 16px;
+}
+
+.newConversationButton {
   font-weight: 600;
-  font-size: 20px;
-  color: #1578d4;
+  line-height: 16px;
+  height: 40px;
+  background-color: white;
+  border-radius: 8px;
+  border: 1px solid var(--color-airy-blue);
+  cursor: pointer;
+  padding: 8px 10px;
+  &:hover {
+    background-color: rgba(128, 128, 128, 0.173);
+  }
 }

--- a/frontend/chat-plugin/src/components/newConversation/index.tsx
+++ b/frontend/chat-plugin/src/components/newConversation/index.tsx
@@ -4,7 +4,7 @@ import {cyChatPluginStartNewConversation} from 'chat-plugin-handles';
 
 type newConversationProps = {
   reAuthenticate: () => void;
-  startConversationText: string;
+  startNewConversationText: string;
 };
 
 const NewConversation = (props: newConversationProps) => {
@@ -21,7 +21,7 @@ const NewConversation = (props: newConversationProps) => {
             onClick={props.reAuthenticate}
             data-cy={cyChatPluginStartNewConversation}
             className={style.newConversationLink}>
-            {props.startConversationText || 'Start a new Conversation'}
+            {props.startNewConversationText || 'Start a new Conversation'}
           </a>
         </button>
       </div>

--- a/frontend/chat-plugin/src/components/newConversation/index.tsx
+++ b/frontend/chat-plugin/src/components/newConversation/index.tsx
@@ -4,24 +4,26 @@ import {cyChatPluginStartNewConversation} from 'chat-plugin-handles';
 
 type newConversationProps = {
   reAuthenticate: () => void;
+  startConversationText: string;
 };
 
 const NewConversation = (props: newConversationProps) => {
   return (
     <div>
       <div className={style.paragraphWrapper}>
-        <p className={style.newConversation}>Your conversation has ended. Thank you for</p>{' '}
-        <p className={style.newConversationLine}>chatting with us today.</p>
+        <p className={style.newConversation}>Your conversation has ended.</p>
       </div>
 
-      <div>
-        <a
-          href=""
-          onClick={props.reAuthenticate}
-          className={style.newConversationLink}
-          data-cy={cyChatPluginStartNewConversation}>
-          Click Here To Start a New Conversation
-        </a>
+      <div className={style.startConversationContainer}>
+        <button className={style.newConversationButton}>
+          <a
+            href=""
+            onClick={props.reAuthenticate}
+            data-cy={cyChatPluginStartNewConversation}
+            className={style.newConversationLink}>
+            {props.startConversationText || 'Start a new Conversation'}
+          </a>
+        </button>
       </div>
     </div>
   );

--- a/frontend/chat-plugin/src/config.ts
+++ b/frontend/chat-plugin/src/config.ts
@@ -7,7 +7,7 @@ export type RenderProp = (ctrl?: RenderCtrl) => JSX.Element;
 export type Config = {
   welcomeMessage?: {};
   headerText?: string;
-  startConversationText?: string;
+  startNewConversationText?: string;
   headerTextColor?: string;
   backgroundColor?: string;
   primaryColor?: string;

--- a/frontend/chat-plugin/src/config.ts
+++ b/frontend/chat-plugin/src/config.ts
@@ -7,6 +7,7 @@ export type RenderProp = (ctrl?: RenderCtrl) => JSX.Element;
 export type Config = {
   welcomeMessage?: {};
   headerText?: string;
+  startConversationText?: string;
   headerTextColor?: string;
   backgroundColor?: string;
   primaryColor?: string;

--- a/frontend/ui/src/pages/Channels/Providers/Airy/ChatPlugin/sections/CustomiseSection.tsx
+++ b/frontend/ui/src/pages/Channels/Providers/Airy/ChatPlugin/sections/CustomiseSection.tsx
@@ -12,6 +12,7 @@ interface CustomiseSectionProps {
 
 export const CustomiseSection = ({channelId, host}: CustomiseSectionProps) => {
   const [headerText, setHeaderText] = useState('');
+  const [startConversationText, setStartConversationText] = useState('');
   const [bubbleIconUrl, setBubbleIconUrl] = useState('');
   const [sendMessageIconUrl, setSendMessageIconUrl] = useState('');
   const [headerTextColor, setHeaderTextColor] = useState('');
@@ -44,6 +45,7 @@ export const CustomiseSection = ({channelId, host}: CustomiseSectionProps) => {
   const getTemplateConfig = () => {
     if (
       headerText === '' &&
+      startConversationText === '' &&
       bubbleIconUrl === '' &&
       sendMessageIconUrl === '' &&
       headerTextColor === '' &&
@@ -55,6 +57,7 @@ export const CustomiseSection = ({channelId, host}: CustomiseSectionProps) => {
     }
     let config = '';
     if (headerText !== '') config += `\n              headerText: '${headerText}',`;
+    if (startConversationText !== '') config += `\n    startConversationText: '${startConversationText}',`;
     if (bubbleIconUrl !== '') config += `\n              bubbleIcon: '${bubbleIconUrl}',`;
     if (sendMessageIconUrl !== '') config += `\n              sendMessageIcon: '${sendMessageIconUrl}',`;
     if (headerTextColor !== '') config += `\n              headerTextColor: '${headerTextColor}',`;
@@ -73,6 +76,7 @@ export const CustomiseSection = ({channelId, host}: CustomiseSectionProps) => {
     config: {
       showMode: true,
       ...(headerText && {headerText}),
+      ...(startConversationText && {startConversationText}),
       ...(headerTextColor && {headerTextColor}),
       ...(primaryColor && {primaryColor}),
       ...(accentColor && {accentColor}),
@@ -122,6 +126,18 @@ export const CustomiseSection = ({channelId, host}: CustomiseSectionProps) => {
             setHeaderText(e.target.value);
           }}
           label="Header Text"
+          placeholder="(optionally) add a text"
+          height={32}
+          fontClass="font-base"
+        />
+        <Input
+          type="text"
+          name="startConversationText"
+          value={startConversationText}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            setStartConversationText(e.target.value);
+          }}
+          label="Start Conversation Text"
           placeholder="(optionally) add a text"
           height={32}
           fontClass="font-base"

--- a/frontend/ui/src/pages/Channels/Providers/Airy/ChatPlugin/sections/CustomiseSection.tsx
+++ b/frontend/ui/src/pages/Channels/Providers/Airy/ChatPlugin/sections/CustomiseSection.tsx
@@ -12,7 +12,7 @@ interface CustomiseSectionProps {
 
 export const CustomiseSection = ({channelId, host}: CustomiseSectionProps) => {
   const [headerText, setHeaderText] = useState('');
-  const [startConversationText, setStartConversationText] = useState('');
+  const [startNewConversationText, setStartNewConversationText] = useState('');
   const [bubbleIconUrl, setBubbleIconUrl] = useState('');
   const [sendMessageIconUrl, setSendMessageIconUrl] = useState('');
   const [headerTextColor, setHeaderTextColor] = useState('');
@@ -45,7 +45,7 @@ export const CustomiseSection = ({channelId, host}: CustomiseSectionProps) => {
   const getTemplateConfig = () => {
     if (
       headerText === '' &&
-      startConversationText === '' &&
+      startNewConversationText === '' &&
       bubbleIconUrl === '' &&
       sendMessageIconUrl === '' &&
       headerTextColor === '' &&
@@ -57,7 +57,7 @@ export const CustomiseSection = ({channelId, host}: CustomiseSectionProps) => {
     }
     let config = '';
     if (headerText !== '') config += `\n              headerText: '${headerText}',`;
-    if (startConversationText !== '') config += `\n    startConversationText: '${startConversationText}',`;
+    if (startNewConversationText !== '') config += `\n    startNewConversationText: '${startNewConversationText}',`;
     if (bubbleIconUrl !== '') config += `\n              bubbleIcon: '${bubbleIconUrl}',`;
     if (sendMessageIconUrl !== '') config += `\n              sendMessageIcon: '${sendMessageIconUrl}',`;
     if (headerTextColor !== '') config += `\n              headerTextColor: '${headerTextColor}',`;
@@ -76,7 +76,7 @@ export const CustomiseSection = ({channelId, host}: CustomiseSectionProps) => {
     config: {
       showMode: true,
       ...(headerText && {headerText}),
-      ...(startConversationText && {startConversationText}),
+      ...(startNewConversationText && {startNewConversationText}),
       ...(headerTextColor && {headerTextColor}),
       ...(primaryColor && {primaryColor}),
       ...(accentColor && {accentColor}),
@@ -132,12 +132,12 @@ export const CustomiseSection = ({channelId, host}: CustomiseSectionProps) => {
         />
         <Input
           type="text"
-          name="startConversationText"
-          value={startConversationText}
+          name="startNewConversationText"
+          value={startNewConversationText}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setStartConversationText(e.target.value);
+            setStartNewConversationText(e.target.value);
           }}
-          label="Start Conversation Text"
+          label="Start new Conversation Text"
           placeholder="(optionally) add a text"
           height={32}
           fontClass="font-base"


### PR DESCRIPTION
closes #1726 

- the Start Conversation button text is customizable + takes the color of the Primary Color

<img width="1434" alt="Screenshot 2021-05-05 at 14 49 08" src="https://user-images.githubusercontent.com/38159391/117143395-1353ae80-adb1-11eb-9563-9a67cc2c98cf.png">

<img width="407" alt="Screenshot 2021-05-05 at 16 11 48" src="https://user-images.githubusercontent.com/38159391/117154912-9e867180-adbc-11eb-9317-520d7df355ae.png">
