### PR TITLE
[#1736] improve render library for facebook

### DIFF
--- a/lib/typescript/render/components/Text/index.module.scss
+++ b/lib/typescript/render/components/Text/index.module.scss
@@ -12,12 +12,30 @@
   font-family: 'Lato', sans-serif;
 }
 
-.contactContent {
+.contactContent,
+.contactContent:hover,
+.contactContent:active,
+.contactContent:visited,
+.contactContent:focus {
   background: var(--color-background-blue);
   color: var(--color-text-contrast);
 }
 
-.memberContent {
+.memberContent, 
+.memberContent:hover,
+.memberContent:active,
+.memberContent:visited,
+.memberContent:focus {
   background: var(--color-airy-blue);
   color: white;
+}
+
+
+.messageLink, 
+.messageLink:hover,
+.messageLink:active,
+.messageLink:visited,
+.messageLink:focus {
+  text-decoration: underline;
+  font-weight:normal;
 }

--- a/lib/typescript/render/components/Text/index.module.scss
+++ b/lib/typescript/render/components/Text/index.module.scss
@@ -21,7 +21,7 @@
   color: var(--color-text-contrast);
 }
 
-.memberContent, 
+.memberContent,
 .memberContent:hover,
 .memberContent:active,
 .memberContent:visited,
@@ -30,12 +30,11 @@
   color: white;
 }
 
-
-.messageLink, 
+.messageLink,
 .messageLink:hover,
 .messageLink:active,
 .messageLink:visited,
 .messageLink:focus {
   text-decoration: underline;
-  font-weight:normal;
+  font-weight: normal;
 }

--- a/lib/typescript/render/components/Text/index.module.scss
+++ b/lib/typescript/render/components/Text/index.module.scss
@@ -30,11 +30,7 @@
   color: white;
 }
 
-.messageLink,
-.messageLink:hover,
-.messageLink:active,
-.messageLink:visited,
-.messageLink:focus {
+.messageLink {
   text-decoration: underline;
   font-weight: normal;
 }

--- a/lib/typescript/render/components/Text/index.tsx
+++ b/lib/typescript/render/components/Text/index.tsx
@@ -13,7 +13,7 @@ export const Text = ({text, fromContact}: TextRenderProps) => (
     className={`${styles.textMessage} ${fromContact ? styles.contactContent : styles.memberContent}`}
     options={{
       defaultProtocol: 'https',
-      className: `${styles.messageLink} ${fromContact ? styles.contactContent : styles.memberContent}`
+      className: `${styles.messageLink} ${fromContact ? styles.contactContent : styles.memberContent}`,
     }}>
     {text}
   </Linkify>

--- a/lib/typescript/render/components/Text/index.tsx
+++ b/lib/typescript/render/components/Text/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Linkify from 'linkifyjs/react';
 import styles from './index.module.scss';
 
 type TextRenderProps = {
@@ -7,5 +8,13 @@ type TextRenderProps = {
 };
 
 export const Text = ({text, fromContact}: TextRenderProps) => (
-  <div className={`${styles.textMessage} ${fromContact ? styles.contactContent : styles.memberContent}`}>{text}</div>
+  <Linkify
+    tagName="div"
+    className={`${styles.textMessage} ${fromContact ? styles.contactContent : styles.memberContent}`}
+    options={{
+      defaultProtocol: 'https',
+      className: `${styles.messageLink} ${fromContact ? styles.contactContent : styles.memberContent}`
+    }}>
+    {text}
+  </Linkify>
 );

--- a/lib/typescript/render/components/Video/index.module.scss
+++ b/lib/typescript/render/components/Video/index.module.scss
@@ -4,6 +4,7 @@
 .wrapper {
   display: flex;
   flex: none;
+  margin-top: 5px;
 }
 
 .item {

--- a/lib/typescript/render/providers/facebook/FacebookRender.tsx
+++ b/lib/typescript/render/providers/facebook/FacebookRender.tsx
@@ -19,35 +19,50 @@ function render(content: ContentUnion, props: RenderPropsUnion) {
   switch (content.type) {
     case 'text':
       return <Text fromContact={props.content.fromContact || false} text={content.text} />;
-    
+
     case 'fallback':
       return (
         <>
-        {content.title && (
-            <Text fromContact={props.content.fromContact || false} text={content.title} />
-        )}
-       
-       {content.url && (
-            <Text fromContact={props.content.fromContact || false} text={content.url} />
-       )}
-       
+          {content.text && <Text fromContact={props.content.fromContact || false} text={content.text} />}
+
+          {content.title && <Text fromContact={props.content.fromContact || false} text={content.title} />}
+
+          {content.url && <Text fromContact={props.content.fromContact || false} text={content.url} />}
         </>
-      )
-        
+      );
+
     case 'postback':
       return <Text fromContact={props.content.fromContact || false} text={content.title} />;
 
     case 'image':
-      return <Image imageUrl={content.imageUrl} />;
+      return (
+        <>
+          {content.text && <Text fromContact={props.content.fromContact || false} text={content.text} />}
+
+          <Image imageUrl={content.imageUrl} />
+        </>
+      );
 
     case 'video':
-      return <Video videoUrl={content.videoUrl} />;
+      return (
+        <>
+          {content.text && <Text fromContact={props.content.fromContact || false} text={content.text} />}
+
+          <Video videoUrl={content.videoUrl} />
+        </>
+      );
 
     case 'buttonTemplate':
       return <ButtonTemplate template={content} />;
 
     case 'genericTemplate':
-      return <GenericTemplate template={content} />;
+      return (
+        <>
+          {content.text && <Text fromContact={props.content.fromContact || false} text={content.text} />}
+
+          <GenericTemplate template={content} />
+        </>
+      );
 
     case 'quickReplies':
       return (
@@ -90,7 +105,6 @@ const parseAttachment = (attachment: SimpleAttachment | ButtonAttachment | Gener
       videoUrl: attachment.payload.url,
     };
   }
-
 
   if (attachment.type === 'fallback') {
     return {
@@ -162,14 +176,14 @@ function facebookOutbound(message: Message): ContentUnion {
     };
   }
 
-  if ((messageJson.attachment || messageJson.attachments) && messageJson.text) {
-    return {
-      type: 'text',
-      text: messageJson.text,
-    };
-  }
-
   if (messageJson.attachment || messageJson.attachments) {
+    if ('text' in messageJson) {
+      return {
+        ...parseAttachment(messageJson.attachment || messageJson.attachments[0]),
+        text: messageJson.text,
+      };
+    }
+
     return parseAttachment(messageJson.attachment || messageJson.attachments[0]);
   }
 

--- a/lib/typescript/render/providers/facebook/FacebookRender.tsx
+++ b/lib/typescript/render/providers/facebook/FacebookRender.tsx
@@ -19,7 +19,21 @@ function render(content: ContentUnion, props: RenderPropsUnion) {
   switch (content.type) {
     case 'text':
       return <Text fromContact={props.content.fromContact || false} text={content.text} />;
-
+    
+    case 'fallback':
+      return (
+        <>
+        {content.title && (
+            <Text fromContact={props.content.fromContact || false} text={content.title} />
+        )}
+       
+       {content.url && (
+            <Text fromContact={props.content.fromContact || false} text={content.url} />
+       )}
+       
+        </>
+      )
+        
     case 'postback':
       return <Text fromContact={props.content.fromContact || false} text={content.title} />;
 
@@ -74,6 +88,15 @@ const parseAttachment = (attachment: SimpleAttachment | ButtonAttachment | Gener
     return {
       type: 'video',
       videoUrl: attachment.payload.url,
+    };
+  }
+
+
+  if (attachment.type === 'fallback') {
+    return {
+      type: 'fallback',
+      title: attachment.payload.title,
+      url: attachment.payload.url,
     };
   }
 
@@ -136,6 +159,13 @@ function facebookOutbound(message: Message): ContentUnion {
       type: 'quickReplies',
       text: messageJson.text,
       quickReplies: messageJson.quick_replies,
+    };
+  }
+
+  if ((messageJson.attachment || messageJson.attachments) && messageJson.text) {
+    return {
+      type: 'text',
+      text: messageJson.text,
     };
   }
 

--- a/lib/typescript/render/providers/facebook/facebookModel.ts
+++ b/lib/typescript/render/providers/facebook/facebookModel.ts
@@ -93,6 +93,13 @@ export interface GenericTemplate extends Content {
   elements: Element[];
 }
 
+export interface Fallback extends Content {
+  type: 'fallback';
+  title: string;
+  url: string;
+
+}
+
 // Add a new facebook content model here:
 export type ContentUnion =
   | TextContent
@@ -101,5 +108,6 @@ export type ContentUnion =
   | VideoContent
   | ButtonTemplate
   | GenericTemplate
-  | QuickRepliesContent;
-export type AttachmentUnion = TextContent | ImageContent | VideoContent | ButtonTemplate | GenericTemplate;
+  | QuickRepliesContent
+  | Fallback;
+export type AttachmentUnion = TextContent | ImageContent | VideoContent | ButtonTemplate | GenericTemplate | Fallback;

--- a/lib/typescript/render/providers/facebook/facebookModel.ts
+++ b/lib/typescript/render/providers/facebook/facebookModel.ts
@@ -54,11 +54,13 @@ export interface Postback extends Content {
 
 export interface ImageContent extends Content {
   type: 'image';
+  text?: string;
   imageUrl: string;
 }
 
 export interface VideoContent extends Content {
   type: 'video';
+  text?: string;
   videoUrl: string;
 }
 
@@ -90,14 +92,15 @@ export interface ButtonTemplate extends Content {
 
 export interface GenericTemplate extends Content {
   type: 'genericTemplate';
+  text?: string;
   elements: Element[];
 }
 
 export interface Fallback extends Content {
   type: 'fallback';
+  text?: string;
   title: string;
   url: string;
-
 }
 
 // Add a new facebook content model here:


### PR DESCRIPTION
closes #1736 

**changes:** 
- enabled links in messages 
- added Facebook Fallback attachment (mainly used for URLs)
- improved FB render library to support text sent with attachments 

**screenshots** 

Fallback attachment example (text / title / URL)

<img width="607" alt="Screenshot 2021-05-07 at 16 29 09" src="https://user-images.githubusercontent.com/38159391/117469905-821e3c80-af56-11eb-8e35-6ee18aa3fd59.png">

Text with attachment example 

<img width="389" alt="Screenshot 2021-05-07 at 16 28 05" src="https://user-images.githubusercontent.com/38159391/117469962-92361c00-af56-11eb-98b5-6a34d0b41626.png">



