### PR TITLE
[#1798] fix not rendered content messages in facebook render library

### DIFF
--- a/lib/typescript/render/providers/facebook/FacebookRender.tsx
+++ b/lib/typescript/render/providers/facebook/FacebookRender.tsx
@@ -145,15 +145,17 @@ const parseAttachment = (
 };
 
 function facebookInbound(message: Message): ContentUnion {
-  const messageJson = message.content;
+  const messageJson = message.content ?? message.content.message;
 
-  if (messageJson.message?.attachments?.length) {
-    return parseAttachment(messageJson.message.attachments[0]);
-  } else if (messageJson.message?.text) {
+  if (messageJson.attachments?.length && messageJson.attachments?.type === 'fallback') {
     return {
-      type: 'text',
-      text: messageJson.message?.text,
+      text: messageJson.text ?? null,
+      ...parseAttachment(messageJson.attachment || messageJson.attachments[0]),
     };
+  }
+
+  if (messageJson.attachments?.length) {
+    return parseAttachment(messageJson.message.attachments[0]);
   }
 
   if (messageJson.postback?.title) {
@@ -164,10 +166,10 @@ function facebookInbound(message: Message): ContentUnion {
     };
   }
 
-  if (messageJson.message?.text) {
+  if (messageJson.text) {
     return {
       type: 'text',
-      text: messageJson.message.text,
+      text: messageJson.text,
     };
   }
 

--- a/lib/typescript/render/providers/facebook/FacebookRender.tsx
+++ b/lib/typescript/render/providers/facebook/FacebookRender.tsx
@@ -5,7 +5,7 @@ import {Text} from '../../components/Text';
 import {Image} from '../../components/Image';
 import {Video} from '../../components/Video';
 import {QuickReplies} from './components/QuickReplies';
-import {AttachmentUnion, SimpleAttachment, ContentUnion, ButtonAttachment, GenericAttachment} from './facebookModel';
+import {AttachmentUnion, SimpleAttachment, ContentUnion, ButtonAttachment, GenericAttachment,  MediaAttachment} from './facebookModel';
 import {ButtonTemplate} from './components/ButtonTemplate';
 import {GenericTemplate} from './components/GenericTemplate';
 
@@ -76,7 +76,9 @@ function render(content: ContentUnion, props: RenderPropsUnion) {
   }
 }
 
-const parseAttachment = (attachment: SimpleAttachment | ButtonAttachment | GenericAttachment): AttachmentUnion => {
+const parseAttachment = (
+  attachment: SimpleAttachment | ButtonAttachment | GenericAttachment | MediaAttachment
+): AttachmentUnion => {
   if (attachment.type === 'image') {
     return {
       type: 'image',
@@ -122,6 +124,7 @@ const parseAttachment = (attachment: SimpleAttachment | ButtonAttachment | Gener
 
 function facebookInbound(message: Message): ContentUnion {
   const messageJson = message.content;
+  console.log('INBOUND', messageJson);
 
   if (messageJson.message?.attachments?.length) {
     return parseAttachment(messageJson.message.attachments[0]);
@@ -155,6 +158,7 @@ function facebookInbound(message: Message): ContentUnion {
 
 function facebookOutbound(message: Message): ContentUnion {
   const messageJson = message.content.message ?? message.content;
+  console.log('OUTOUND', messageJson);
 
   if (messageJson.quick_replies) {
     if (messageJson.quick_replies.length > 13) {

--- a/lib/typescript/render/providers/facebook/FacebookRender.tsx
+++ b/lib/typescript/render/providers/facebook/FacebookRender.tsx
@@ -117,7 +117,8 @@ const parseAttachment = (
     return {
       type: 'mediaTemplate',
       media_type: attachment.payload.elements[0].media_type,
-      url: attachment.payload.elements[0].url,
+      url: attachment.payload.elements[0].url ?? null,
+      attachment_id: attachment.payload.elements[0].attachment_id ?? null,
       buttons: attachment.payload.elements[0].buttons,
     };
   }
@@ -146,15 +147,13 @@ const parseAttachment = (
 function facebookInbound(message: Message): ContentUnion {
   const messageJson = message.content;
 
-  if (messageJson.attachment.type === 'fallback' || messageJson.attachments.type === 'fallback') {
+  if (messageJson.message?.attachments?.length) {
+    return parseAttachment(messageJson.message.attachments[0]);
+  } else if (messageJson.message?.text) {
     return {
-      ...parseAttachment(messageJson.attachment || messageJson.attachments[0]),
-      text: messageJson.text ?? null,
+      type: 'text',
+      text: messageJson.message?.text,
     };
-  }
-
-  if (messageJson.attachment || messageJson.attachments) {
-    return parseAttachment(messageJson.attachment || messageJson.attachments[0]);
   }
 
   if (messageJson.postback?.title) {

--- a/lib/typescript/render/providers/facebook/FacebookRender.tsx
+++ b/lib/typescript/render/providers/facebook/FacebookRender.tsx
@@ -145,7 +145,7 @@ const parseAttachment = (
 };
 
 function facebookInbound(message: Message): ContentUnion {
-  const messageJson = message.content ?? message.content.message;
+  const messageJson = message.content.message ?? message.content;
 
   if (messageJson.attachments?.length && messageJson.attachments?.type === 'fallback') {
     return {

--- a/lib/typescript/render/providers/facebook/FacebookRender.tsx
+++ b/lib/typescript/render/providers/facebook/FacebookRender.tsx
@@ -98,7 +98,7 @@ const parseAttachment = (
     };
   }
 
-  if (attachment.type === 'template' && attachment.payload.template_type == 'button') {
+  if (attachment.type === 'template' && attachment.payload.template_type === 'button') {
     return {
       type: 'buttonTemplate',
       text: attachment.payload.text,
@@ -106,14 +106,14 @@ const parseAttachment = (
     };
   }
 
-  if (attachment.type === 'template' && attachment.payload.template_type == 'generic') {
+  if (attachment.type === 'template' && attachment.payload.template_type === 'generic') {
     return {
       type: 'genericTemplate',
       elements: attachment.payload.elements,
     };
   }
 
-  if (attachment.type === 'template' && attachment.payload.template_type == 'media') {
+  if (attachment.type === 'template' && attachment.payload.template_type === 'media') {
     return {
       type: 'mediaTemplate',
       media_type: attachment.payload.elements[0].media_type,
@@ -122,14 +122,14 @@ const parseAttachment = (
     };
   }
 
-  if (attachment.type == 'video') {
+  if (attachment.type === 'video') {
     return {
       type: 'video',
       videoUrl: attachment.payload.url,
     };
   }
 
-  if (attachment.type == 'fallback') {
+  if (attachment.type === 'fallback') {
     return {
       type: 'fallback',
       title: attachment.payload?.title ?? attachment.title,

--- a/lib/typescript/render/providers/facebook/components/ButtonTemplate/index.module.scss
+++ b/lib/typescript/render/providers/facebook/components/ButtonTemplate/index.module.scss
@@ -16,25 +16,6 @@
   padding: 16px;
 }
 
-.button {
-  font-weight: 700;
-  background-color: var(--color-template-highlight);
-  border-radius: 8px;
-  margin-top: 16px;
-  text-align: center;
-}
-
-.buttonText {
-  color: var(--color-contrast);
-  text-decoration: none;
-  padding: 8px;
-  display: block;
-  &:hover {
-    color: var(--color-contrast);
-    text-decoration: none;
-  }
-}
-
 .messageTime {
   @include font-s;
   color: var(--color-text-gray);

--- a/lib/typescript/render/providers/facebook/components/ButtonTemplate/index.tsx
+++ b/lib/typescript/render/providers/facebook/components/ButtonTemplate/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Buttons} from '../Buttons';
 
 import {ButtonTemplate as ButtonTemplateModel} from '../../facebookModel';
 
@@ -12,19 +13,7 @@ export const ButtonTemplate = ({template}: ButtonTemplateRendererProps) => (
   <div className={styles.wrapper}>
     <div className={styles.template}>
       <div className={styles.tempateText}>{template.text}</div>
-      {template.buttons.map((button, idx) => {
-        return (
-          <div key={`button-${idx}`} className={styles.button}>
-            {button.type == 'web_url' && button.url.length ? (
-              <a href={button.url} target="_blank" rel="noreferrer" className={styles.buttonText}>
-                {button.title}
-              </a>
-            ) : (
-              <div className={styles.buttonText}>{button.title}</div>
-            )}
-          </div>
-        );
-      })}
+      <Buttons buttons={template.buttons} />
     </div>
   </div>
 );

--- a/lib/typescript/render/providers/facebook/components/Buttons/index.module.scss
+++ b/lib/typescript/render/providers/facebook/components/Buttons/index.module.scss
@@ -1,0 +1,21 @@
+.button {
+  font-weight: 700;
+  background-color: var(--color-template-highlight);
+  border-radius: 8px;
+  text-align: center;
+}
+
+.buttonMargin {
+  margin-top: 16px;
+}
+
+.buttonText {
+  color: var(--color-contrast);
+  text-decoration: none;
+  padding: 8px;
+  display: block;
+  &:hover {
+    color: var(--color-contrast);
+    text-decoration: none;
+  }
+}

--- a/lib/typescript/render/providers/facebook/components/Buttons/index.tsx
+++ b/lib/typescript/render/providers/facebook/components/Buttons/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {URLButton, PostbackButton, CallButton, LoginButton, LogoutButton, GamePlayButton} from '../../facebookModel';
+import styles from './index.module.scss';
+
+type ButtonsProps = {
+  buttons: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton | GamePlayButton)[];
+  mediaTemplate?: boolean;
+};
+
+export const Buttons = ({buttons, mediaTemplate}: ButtonsProps) => {
+  return (
+    <>
+      {buttons.map((button, idx) => {
+        return (
+          <div key={`button-${idx}`} className={`${styles.button} ${mediaTemplate ? '' : styles.buttonMargin}`}>
+            {button.type === 'web_url' && button.url.length ? (
+              <a href={button.url} target="_blank" rel="noreferrer" className={styles.buttonText}>
+                {button.title}
+              </a>
+            ) : button.type === 'account_link' ? (
+              <div className={styles.buttonText}>Log In</div>
+            ) : button.type === 'account_unlink' ? (
+              <div className={styles.buttonText}>Log Out</div>
+            ) : (
+              <div className={styles.buttonText}>{button.title}</div>
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+};

--- a/lib/typescript/render/providers/facebook/components/GenericTemplate/index.module.scss
+++ b/lib/typescript/render/providers/facebook/components/GenericTemplate/index.module.scss
@@ -25,22 +25,3 @@
 .innerTemplate {
   padding: 8px 16px 16px 16px;
 }
-
-.button {
-  font-weight: 700;
-  background-color: var(--color-template-highlight);
-  border-radius: 8px;
-  margin-top: 16px;
-  text-align: center;
-}
-
-.buttonText {
-  color: var(--color-contrast);
-  text-decoration: none;
-  padding: 8px;
-  display: block;
-  &:hover {
-    color: var(--color-contrast);
-    text-decoration: none;
-  }
-}

--- a/lib/typescript/render/providers/facebook/components/GenericTemplate/index.tsx
+++ b/lib/typescript/render/providers/facebook/components/GenericTemplate/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {Carousel} from 'components';
 import {GenericTemplate as GenericTemplateModel} from '../../facebookModel';
 import {ImageWithFallback} from 'render/components/ImageWithFallback';
+import {Buttons} from '../Buttons';
 
 import styles from './index.module.scss';
 
@@ -19,19 +20,7 @@ export const GenericTemplate = ({template}: GenericTemplateRendererProps) => {
           <div className={styles.innerTemplate}>
             <div className={styles.templateTitle}>{element.title}</div>
             <div className={styles.templateSubtitle}>{element.subtitle}</div>
-            {element.buttons.map((button, idx) => {
-              return (
-                <div key={`button-${idx}`} className={styles.button}>
-                  {button.type == 'web_url' && button.url.length ? (
-                    <a href={button.url} target="_blank" rel="noreferrer" className={styles.buttonText}>
-                      {button.title}
-                    </a>
-                  ) : (
-                    <div className={styles.buttonText}>{button.title}</div>
-                  )}
-                </div>
-              );
-            })}
+            <Buttons buttons={element.buttons} />
           </div>
         </div>
       ))}

--- a/lib/typescript/render/providers/facebook/components/MediaTemplate/index.module.scss
+++ b/lib/typescript/render/providers/facebook/components/MediaTemplate/index.module.scss
@@ -14,3 +14,7 @@
 .mediaBorder {
   border-bottom: 1px solid var(--color-light-gray);
 }
+
+.mediaInfo {
+  color: var(--color-airy-blue);
+}

--- a/lib/typescript/render/providers/facebook/components/MediaTemplate/index.module.scss
+++ b/lib/typescript/render/providers/facebook/components/MediaTemplate/index.module.scss
@@ -1,0 +1,16 @@
+@import 'assets/scss/colors.scss';
+@import 'assets/scss/fonts.scss';
+
+.mediaTemplate {
+  max-width: 500px;
+  border-radius: 8px;
+  border: 1px solid var(--color-light-gray);
+}
+
+.media {
+  padding: 20px 10px;
+}
+
+.mediaBorder {
+  border-bottom: 1px solid var(--color-light-gray);
+}

--- a/lib/typescript/render/providers/facebook/components/MediaTemplate/index.tsx
+++ b/lib/typescript/render/providers/facebook/components/MediaTemplate/index.tsx
@@ -1,0 +1,49 @@
+import { getTextMessagePayload } from 'httpclient';
+import React from 'react';
+import {MediaTemplate as MediaTemplateModel} from '../../facebookModel';
+import styles from './index.module.scss';
+
+type MediaTemplateProps = {
+  template: MediaTemplateModel;
+};
+
+//media_type: 'video' | 'image';
+//url: string;
+//buttons?: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton)[];
+
+//add svg link in mediaType
+
+export const MediaTemplate = ({template: {media_type, url, buttons}}: MediaTemplateProps) => {
+  return (
+    <div>
+      <a href={url} target="_blank" rel="noopener noreferrer">
+        view the {media_type} on Facebook
+      </a>
+      {buttons.map((button, idx) => {
+              return (
+                <div key={`button-${idx}`} className={styles.button}>
+                  {button.type === 'web_url' && url.length &&(
+                    <a href={url} target="_blank" rel="noreferrer" className={styles.buttonText}>
+                      {button.title}
+                    </a>
+                  )}
+
+                {button.type === 'account_link' && url.length &&(
+                    <a href={url} target="_blank" rel="noreferrer" className={styles.buttonText}>
+                      {button.title}
+                    </a>
+                  )}
+
+
+                </div>
+              );
+            })}
+    </div>
+  );
+};
+
+
+//web URL 
+//login button 
+//logout button 
+//default: render just title 

--- a/lib/typescript/render/providers/facebook/components/MediaTemplate/index.tsx
+++ b/lib/typescript/render/providers/facebook/components/MediaTemplate/index.tsx
@@ -7,13 +7,17 @@ type MediaTemplateProps = {
   template: MediaTemplateModel;
 };
 
-export const MediaTemplate = ({template: {media_type, url, buttons}}: MediaTemplateProps) => {
+export const MediaTemplate = ({template: {media_type, url, attachment_id, buttons}}: MediaTemplateProps) => {
   return (
     <div className={styles.mediaTemplate}>
       <div className={`${styles.media} ${buttons ? styles.mediaBorder : ''}`}>
-        <a href={url} target="_blank" rel="noopener noreferrer">
-          see the {media_type} on Facebook
-        </a>
+        {url && (
+          <a href={url} target="_blank" rel="noopener noreferrer">
+            see the {media_type} on Facebook
+          </a>
+        )}
+
+        {attachment_id && <span className={styles.mediaInfo}> {media_type} posted on Facebook</span>}
       </div>
       {buttons && <Buttons buttons={buttons} mediaTemplate={true} />}
     </div>

--- a/lib/typescript/render/providers/facebook/components/MediaTemplate/index.tsx
+++ b/lib/typescript/render/providers/facebook/components/MediaTemplate/index.tsx
@@ -1,49 +1,21 @@
-import { getTextMessagePayload } from 'httpclient';
 import React from 'react';
 import {MediaTemplate as MediaTemplateModel} from '../../facebookModel';
+import {Buttons} from '../Buttons';
 import styles from './index.module.scss';
 
 type MediaTemplateProps = {
   template: MediaTemplateModel;
 };
 
-//media_type: 'video' | 'image';
-//url: string;
-//buttons?: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton)[];
-
-//add svg link in mediaType
-
 export const MediaTemplate = ({template: {media_type, url, buttons}}: MediaTemplateProps) => {
   return (
-    <div>
-      <a href={url} target="_blank" rel="noopener noreferrer">
-        view the {media_type} on Facebook
-      </a>
-      {buttons.map((button, idx) => {
-              return (
-                <div key={`button-${idx}`} className={styles.button}>
-                  {button.type === 'web_url' && url.length &&(
-                    <a href={url} target="_blank" rel="noreferrer" className={styles.buttonText}>
-                      {button.title}
-                    </a>
-                  )}
-
-                {button.type === 'account_link' && url.length &&(
-                    <a href={url} target="_blank" rel="noreferrer" className={styles.buttonText}>
-                      {button.title}
-                    </a>
-                  )}
-
-
-                </div>
-              );
-            })}
+    <div className={styles.mediaTemplate}>
+      <div className={`${styles.media} ${buttons ? styles.mediaBorder : ''}`}>
+        <a href={url} target="_blank" rel="noopener noreferrer">
+          see the {media_type} on Facebook
+        </a>
+      </div>
+      {buttons && <Buttons buttons={buttons} mediaTemplate={true} />}
     </div>
   );
 };
-
-
-//web URL 
-//login button 
-//logout button 
-//default: render just title 

--- a/lib/typescript/render/providers/facebook/facebookModel.ts
+++ b/lib/typescript/render/providers/facebook/facebookModel.ts
@@ -8,13 +8,6 @@ export interface SimpleAttachment {
   payload?: {title?: string; url?: string} | null;
 }
 
-export interface Fallback extends Content {
-  type: 'fallback';
-  text?: string;
-  title: string;
-  url: string;
-}
-
 export interface URLButton extends Content {
   type: 'web_url';
   url: string;
@@ -139,6 +132,13 @@ export interface GenericTemplate extends Content {
   type: 'genericTemplate';
   text?: string;
   elements: Element[];
+}
+
+export interface Fallback extends Content {
+  type: 'fallback';
+  text?: string;
+  title: string;
+  url: string;
 }
 
 // Add a new facebook content model here:

--- a/lib/typescript/render/providers/facebook/facebookModel.ts
+++ b/lib/typescript/render/providers/facebook/facebookModel.ts
@@ -5,7 +5,14 @@ export interface SimpleAttachment {
   type: 'image' | 'video' | 'audio' | 'file' | 'fallback';
   title?: string;
   url?: string;
-  payload?: { title?: string; url?: string};
+  payload?: {title?: string; url?: string} | null;
+}
+
+export interface Fallback extends Content {
+  type: 'fallback';
+  text?: string;
+  title: string;
+  url: string;
 }
 
 export interface URLButton extends Content {
@@ -24,15 +31,25 @@ export interface CallButton extends Content {
   type: 'phone_number';
   title: string;
   payload: string;
-  }
+}
 
 export interface LoginButton extends Content {
-  type: "account_link";
+  type: 'account_link';
   url: string;
 }
 
-export interface LogoutButton extends Content{
-  type: "account_unlink";
+export interface LogoutButton extends Content {
+  type: 'account_unlink';
+}
+
+export interface GamePlayButton extends Content {
+  type: 'game_play';
+  title: 'Play';
+  payload?: string;
+  game_metadata?: {
+    player_id?: string;
+    context_id?: string;
+  };
 }
 
 export interface ButtonAttachment extends Attachment {
@@ -40,7 +57,7 @@ export interface ButtonAttachment extends Attachment {
   payload: {
     text: string;
     template_type: 'button';
-    buttons: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton)[];
+    buttons: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton | GamePlayButton)[];
   };
 }
 export interface GenericAttachment extends Attachment {
@@ -52,15 +69,11 @@ export interface GenericAttachment extends Attachment {
   };
 }
 
-
-export interface FallbackAttachment extends SimpleAttachment {
-  type: 'fallback';
-}
-
-export interface MediaTemplate {
+export interface MediaTemplate extends Content {
+  type: 'mediaTemplate';
   media_type: 'video' | 'image';
   url: string;
-  buttons?: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton)[];
+  buttons: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton | GamePlayButton)[];
 }
 
 export interface MediaAttachment extends Attachment {
@@ -79,11 +92,12 @@ export interface Element {
     type: string;
     url?: string;
   };
-  buttons: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton)[];
+  buttons: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton | GamePlayButton)[];
 }
 
 export interface Content {
   type: string;
+  text?: string;
 }
 
 export interface TextContent extends Content {
@@ -93,13 +107,11 @@ export interface TextContent extends Content {
 
 export interface ImageContent extends Content {
   type: 'image';
-  text?: string;
   imageUrl: string;
 }
 
 export interface VideoContent extends Content {
   type: 'video';
-  text?: string;
   videoUrl: string;
 }
 
@@ -117,11 +129,10 @@ export interface QuickRepliesContent extends Content {
   quickReplies: QuickReply[];
 }
 
-
 export interface ButtonTemplate extends Content {
   type: 'buttonTemplate';
   text: string;
-  buttons: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton)[];
+  buttons: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton | GamePlayButton)[];
 }
 
 export interface GenericTemplate extends Content {
@@ -129,8 +140,6 @@ export interface GenericTemplate extends Content {
   text?: string;
   elements: Element[];
 }
-
-
 
 // Add a new facebook content model here:
 export type ContentUnion =
@@ -141,11 +150,14 @@ export type ContentUnion =
   | ButtonTemplate
   | GenericTemplate
   | QuickRepliesContent
-  | MediaAttachment
+  | MediaTemplate
+  | Fallback;
+
 export type AttachmentUnion =
   | TextContent
   | ImageContent
   | VideoContent
   | ButtonTemplate
   | GenericTemplate
-  | MediaAttachment;
+  | MediaTemplate
+  | Fallback;

--- a/lib/typescript/render/providers/facebook/facebookModel.ts
+++ b/lib/typescript/render/providers/facebook/facebookModel.ts
@@ -3,10 +3,36 @@ export interface Attachment {
 }
 export interface SimpleAttachment {
   type: 'image' | 'video' | 'audio' | 'file' | 'fallback';
-  payload: {
-    title?: string;
-    url?: string;
-  };
+  title?: string;
+  url?: string;
+  payload?: { title?: string; url?: string};
+}
+
+export interface URLButton extends Content {
+  type: 'web_url';
+  url: string;
+  title: string;
+}
+
+export interface PostbackButton extends Content {
+  type: 'postback';
+  title: string;
+  payload: string;
+}
+
+export interface CallButton extends Content {
+  type: 'phone_number';
+  title: string;
+  payload: string;
+  }
+
+export interface LoginButton extends Content {
+  type: "account_link";
+  url: string;
+}
+
+export interface LogoutButton extends Content{
+  type: "account_unlink";
 }
 
 export interface ButtonAttachment extends Attachment {
@@ -14,7 +40,7 @@ export interface ButtonAttachment extends Attachment {
   payload: {
     text: string;
     template_type: 'button';
-    buttons: Button[];
+    buttons: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton)[];
   };
 }
 export interface GenericAttachment extends Attachment {
@@ -26,18 +52,23 @@ export interface GenericAttachment extends Attachment {
   };
 }
 
+
+export interface FallbackAttachment extends SimpleAttachment {
+  type: 'fallback';
+}
+
+export interface MediaTemplate {
+  media_type: 'video' | 'image';
+  url: string;
+  buttons?: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton)[];
+}
+
 export interface MediaAttachment extends Attachment {
   type: 'template';
   payload: {
     template_type: 'media';
-    elements: MediaAttachmentElement[];
+    elements: MediaTemplate[];
   };
-}
-
-export interface MediaAttachmentElement {
-  media_type: 'video' | 'image';
-  url: string;
-  buttons?: (Button | Postback)[];
 }
 
 export interface Element {
@@ -48,7 +79,7 @@ export interface Element {
     type: string;
     url?: string;
   };
-  buttons: Button[];
+  buttons: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton)[];
 }
 
 export interface Content {
@@ -58,12 +89,6 @@ export interface Content {
 export interface TextContent extends Content {
   type: 'text';
   text: string;
-}
-
-export interface Postback extends Content {
-  type: 'postback';
-  title: string;
-  payload: string;
 }
 
 export interface ImageContent extends Content {
@@ -92,16 +117,11 @@ export interface QuickRepliesContent extends Content {
   quickReplies: QuickReply[];
 }
 
-export interface Button {
-  type: 'web_url';
-  url: string;
-  title: string;
-}
 
 export interface ButtonTemplate extends Content {
   type: 'buttonTemplate';
   text: string;
-  buttons: Button[];
+  buttons: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton)[];
 }
 
 export interface GenericTemplate extends Content {
@@ -110,23 +130,17 @@ export interface GenericTemplate extends Content {
   elements: Element[];
 }
 
-export interface Fallback extends Content {
-  type: 'fallback';
-  text?: string;
-  title: string;
-  url: string;
-}
+
 
 // Add a new facebook content model here:
 export type ContentUnion =
   | TextContent
-  | Postback
+  | PostbackButton
   | ImageContent
   | VideoContent
   | ButtonTemplate
   | GenericTemplate
   | QuickRepliesContent
-  | Fallback
   | MediaAttachment
 export type AttachmentUnion =
   | TextContent
@@ -134,5 +148,4 @@ export type AttachmentUnion =
   | VideoContent
   | ButtonTemplate
   | GenericTemplate
-  | Fallback
   | MediaAttachment;

--- a/lib/typescript/render/providers/facebook/facebookModel.ts
+++ b/lib/typescript/render/providers/facebook/facebookModel.ts
@@ -65,7 +65,8 @@ export interface GenericAttachment extends Attachment {
 export interface MediaTemplate extends Content {
   type: 'mediaTemplate';
   media_type: 'video' | 'image';
-  url: string;
+  url?: string;
+  attachment_id?: string;
   buttons: (URLButton | PostbackButton | CallButton | LoginButton | LogoutButton | GamePlayButton)[];
 }
 
@@ -95,7 +96,6 @@ export interface Content {
 
 export interface TextContent extends Content {
   type: 'text';
-  text: string;
 }
 
 export interface ImageContent extends Content {

--- a/lib/typescript/render/providers/facebook/facebookModel.ts
+++ b/lib/typescript/render/providers/facebook/facebookModel.ts
@@ -29,7 +29,6 @@ export interface GenericAttachment extends Attachment {
 export interface MediaAttachment extends Attachment {
   type: 'template';
   payload: {
-    text: string;
     template_type: 'media';
     elements: MediaAttachmentElement[];
   };
@@ -38,7 +37,7 @@ export interface MediaAttachment extends Attachment {
 export interface MediaAttachmentElement {
   media_type: 'video' | 'image';
   url: string;
-  buttons: Button[];
+  buttons?: (Button | Postback)[];
 }
 
 export interface Element {
@@ -111,8 +110,6 @@ export interface GenericTemplate extends Content {
   elements: Element[];
 }
 
-//
-
 export interface Fallback extends Content {
   type: 'fallback';
   text?: string;
@@ -129,7 +126,8 @@ export type ContentUnion =
   | ButtonTemplate
   | GenericTemplate
   | QuickRepliesContent
-  | Fallback;
+  | Fallback
+  | MediaAttachment
 export type AttachmentUnion =
   | TextContent
   | ImageContent

--- a/lib/typescript/render/providers/facebook/facebookModel.ts
+++ b/lib/typescript/render/providers/facebook/facebookModel.ts
@@ -26,6 +26,21 @@ export interface GenericAttachment extends Attachment {
   };
 }
 
+export interface MediaAttachment extends Attachment {
+  type: 'template';
+  payload: {
+    text: string;
+    template_type: 'media';
+    elements: MediaAttachmentElement[];
+  };
+}
+
+export interface MediaAttachmentElement {
+  media_type: 'video' | 'image';
+  url: string;
+  buttons: Button[];
+}
+
 export interface Element {
   title: string;
   subtitle?: string;
@@ -96,6 +111,8 @@ export interface GenericTemplate extends Content {
   elements: Element[];
 }
 
+//
+
 export interface Fallback extends Content {
   type: 'fallback';
   text?: string;
@@ -113,4 +130,11 @@ export type ContentUnion =
   | GenericTemplate
   | QuickRepliesContent
   | Fallback;
-export type AttachmentUnion = TextContent | ImageContent | VideoContent | ButtonTemplate | GenericTemplate | Fallback;
+export type AttachmentUnion =
+  | TextContent
+  | ImageContent
+  | VideoContent
+  | ButtonTemplate
+  | GenericTemplate
+  | Fallback
+  | MediaAttachment;


### PR DESCRIPTION
closes #1798 

**Changes** 
- added [Media Template](https://developers.facebook.com/docs/messenger-platform/send-messages/template/media): 
- fixed fallback attachment
- fixed [Buttons](https://developers.facebook.com/docs/messenger-platform/reference/buttons) typings + added more button types
- created a Buttons component that is reused in all templates and supports all the types of buttons 

**Screenshots** 
Media Template: includes video or image (accepts only FB URLs so cannot be embedded) + buttons 
<img width="238" alt="Screenshot 2021-05-21 at 11 40 03" src="https://user-images.githubusercontent.com/38159391/119117204-4b055c00-ba29-11eb-858f-ac3336ab5c58.png">

