### PR TITLE
[#1926] Polishing the docs

### DIFF
--- a/docs/docs/api/introduction.md
+++ b/docs/docs/api/introduction.md
@@ -17,8 +17,16 @@ Interact with your Airy Core via **HTTP Endpoints**, **WebSockets** or
 
 </TLDR>
 
-This documents offers a high-level overview of the different parts that compose
+This document offers a high-level overview of the different parts that compose
 the Airy Core API.
+
+:::warning
+
+Authentication is disabled by default in `Airy Core`.
+
+As this is suitable **only for testing purposes**, we advise you to refer to our [documentation on how to secure the API](/getting-started/installation/security).
+
+:::
 
 Once you connect Airy Core to a [source](/getting-started/glossary.md#source),
 the platform will immediately start consuming conversational data and store it

--- a/docs/docs/api/webhook.md
+++ b/docs/docs/api/webhook.md
@@ -11,6 +11,14 @@ Use Webhooks to receive events to notify you when a variety of interactions or e
 
 </TLDR>
 
+:::note
+
+The webhook integration is not enabled by default.
+
+For more details on how to enable it, refer to our [Configuration Section](getting-started/installation/configuration.md#components).
+
+:::
+
 The webhook integration enables you to programmatically participate in
 conversations by sending messages or reacting to them. Here's a common
 integration pattern:

--- a/docs/docs/cli/introduction.md
+++ b/docs/docs/cli/introduction.md
@@ -137,7 +137,7 @@ airy version
 :tada: Congratulations!
 
 You have successfully installed Airy CLI! Next step: Choose a way to [Deploy
-Airy Core](/getting-started/installation/introduction.md)
+Airy Core](/getting-started/installation/introduction#install-airy-core)
 
 </SuccessBox>
 

--- a/docs/docs/getting-started/installation/configuration.md
+++ b/docs/docs/getting-started/installation/configuration.md
@@ -57,9 +57,9 @@ cluster and Redis.
 
 ### Security
 
-- `systemToken` set to a long secure secret to use for machine [API authentication](api/authentication.md)
+- `systemToken` set to a long secure secret to use for machine [API authentication](security#api-security)
 - `allowedOrigins` your site's origin to prevent CORS-based attacks (default: `"*"`)
-- `oidc` a map of values that when set enable and define [OIDC authentication](api/authentication.md#configuring-oidc)
+- `oidc` a map of values that when set enable and define [OIDC authentication](security#configuring-oidc)
 - `jwtSecret` used to create jwt http sessions derived from oidc authentication (default: randomized on installation)
 
 ### Components
@@ -67,8 +67,15 @@ cluster and Redis.
 - `sources`
 
   - `facebook`
+    - `appId` set this to your Facebook App ID
+    - `appSecret` set this to your Facebook App Secret
+    - `webhookSecret` set this to a webhook secret of your choice (optional)
   - `google`
+    - `saFile` copy here the content of your Google service account key file (one line json string)
+    - `partnerKey` set this to your Google parttner key
   - `twilio`
+    - `authToken` set this to your Twilio authentication token
+    - `accountSid` set this to your Twilio account SID
 
   The **Airy Controller** only starts configured sources. To keep system load to
   a minimum, only add the sources you are using.
@@ -93,6 +100,34 @@ monitor or debug the **Airy Core**.
 
 - `akhq` Kafka GUI for Apache Kafka (For more information visit [akhq.io](https://akhq.io/))
   - `enabled` set to either `true` to start AKHQ or `false` (default) to disable it
+
+### Example airy.yaml file
+
+For example, if you want to enable Facebook, Google and Twilio sources, as well as the webhook integration and the AKHQ tool, your `airy.yaml` file should look like this:
+
+```
+kubernetes:
+  containerRegistry: ghcr.io/airyhq
+  namespace: default
+  ngrokEnabled: false
+security:
+  allowedOrigins: "*"
+  systemToken: "my-token-for-the-api"
+  jwtSecret: "generated-secret-during-installation"
+components:
+  sources:
+    facebook:
+      appId: "fb-app-id"
+      appSecret: "fb-app-secret"
+      webhookSecret: "my-webhook-secret"
+    google:
+      saFile: '{"type": "service_account","project_id": "my-project","private_key_id": "my-private-key-id","private_key": "-----BEGIN PRIVATE KEY-----\nKEY-DATA-\n-----END PRIVATE KEY-----\n","client_email": "some-e-mail","client_id": "client-id",....}'
+      partnerKey: "gl-private-key"
+  integration:
+    webhook:
+      name: webhook
+      maxBackoff: 10
+```
 
 ## Applying the configuration
 

--- a/docs/docs/getting-started/installation/introduction.md
+++ b/docs/docs/getting-started/installation/introduction.md
@@ -21,7 +21,7 @@ We recommend [installing](/cli/introduction.md) the Airy CLI first which will
 aid you in the process of installing and managing your Airy Core instance. It is
 easy to install and works on macOS, Windows, and Linux.
 
-## Installation Guides
+## Install the Airy CLI
 
 <ButtonBoxList>
 <ButtonBox
@@ -31,6 +31,13 @@ title='CLI'
 description='Install the Airy Core CLI application'
 link='/cli/introduction'
 />
+</ButtonBoxList>
+
+## Install Airy Core
+
+After you have installed your Airy CLI you can choose one of the following supported platforms and use the CLI to deploy `Airy Core`.
+
+<ButtonBoxList>
 <ButtonBox
 icon={<Minikube />}
 title='Local test environment with Minikube'

--- a/docs/docs/getting-started/installation/minikube.md
+++ b/docs/docs/getting-started/installation/minikube.md
@@ -4,6 +4,8 @@ sidebar_label: Minikube
 ---
 
 import TLDR from "@site/src/components/TLDR";
+import ButtonBox from "@site/src/components/ButtonBox";
+import DiamondSVG from "@site/static/icons/diamond.svg";
 
 <TLDR>
 Run Airy on minikube with one command.
@@ -78,8 +80,15 @@ change the setting for `server_addr` in the ConfigMap.
 ## Next steps
 
 Now that you have a running local installation of minikube you can connect it to
-messaging sources. Check out the [source
-documentation](/sources/introduction.md) to learn more.
+messaging sources. Check out our Quickstart guide to learn more:
+
+<ButtonBox
+icon={<DiamondSVG />}
+iconInvertible={true}
+title='To the Quick Start'
+description='Learn the Airy Basics with our Quick Start'
+link='getting-started/quickstart'
+/>
 
 ## Third party tools
 

--- a/docs/docs/getting-started/installation/security.md
+++ b/docs/docs/getting-started/installation/security.md
@@ -1,14 +1,32 @@
 ---
-title: Authentication
-sidebar_label: Authentication
+title: Security
+sidebar_label: Security
 ---
+
+## API Security
 
 By default, authentication is disabled. There are two ways of protecting resources from unauthorized access.
 You can set `security.systemToken` in the [cluster configuration](getting-started/installation/configuration.md) to a secure secret value in your `airy.yaml` and apply it. Once that is done you authenticate by setting the token as a value on the [Bearer Authorization header](https://tools.ietf.org/html/rfc6750#section-2.1) when making requests.
 
-This is fine for API only access, but it means that UI clients will no longer work since api keys are not meant for web authentication. Therefore Airy Core also supports [Open Id Connect (OIDC)](https://openid.net/connect/) to allow your agents to authenticate via an external provider. If you configure this in addition to the system token then both types of authentication will work when requesting APIs. If you only configure OIDC authentication then regular
+Apart from the `systemToken` you would also need to set your `system.allowedOrigins` value, for protecting the hostname from which API calls can be made:
+
+```yaml
+security:
+  allowedOrigins: "my.airy.hostname.com"
+  systemToken: "my-token-for-the-api"
+  jwtSecret: "generated-secret-during-installation"
+```
+
+After you apply this configuration, you can query the API with the appropriate systemToken:
+
+```sh
+curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer my-token-for-the-api" http://airy.core/conversations.list
+
+```
 
 ## Configuring OIDC
+
+Setting up the `systemToken` will secure the API, but it means that UI clients will no longer work since API keys are not meant for web authentication. This is why Airy Core also supports [Open Id Connect (OIDC)](https://openid.net/connect/) to allow your agents to authenticate via an external provider. If you configure this in addition to the system token then both types of authentication will work when requesting APIs.
 
 OIDC is an authentication layer on top of the popular OAuth 2.0 authorization framework. With the added information of
 "who" made a request (authentication) Airy Core is able to offer audit and workflow features.
@@ -68,3 +86,9 @@ security:
 ```
 
 The redirect Uri to configure with your provider will always be of the form `{airy core host}/login/oauth2/code/{provider name}`.
+
+## HTTPS
+
+By default the deployed ingress resources don't have HTTPS enabled, so this needs to be configured depending on the provider where you are running `Airy Core`.
+
+We advise you to refer to the documentation of your cloud provider on how to enable HTTPS on the LoadBalancer which routes to the Traefik ingress controller.

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -31,6 +31,14 @@ description='To get going with the Quickstart, you must install Airy first. Once
 link='/getting-started/installation/introduction'
 />
 
+:::note
+
+The Quickstart guide explains setting up and using the Chatplugin source which is enabled by default.
+
+To enable and use other sources, please refer to our [Sources documentation](/sources/introduction).
+
+:::
+
 ## Step 1: How to setup your first source
 
 The [Airy Live Chat Plugin](/sources/chatplugin/overview.md) source is well suited for a

--- a/docs/docs/sources/chatplugin/installation.md
+++ b/docs/docs/sources/chatplugin/installation.md
@@ -15,7 +15,7 @@ the `<head>` section:
     var f = d.getElementsByTagName(s)[0],
       j = d.createElement(s);
     j.async = true;
-    j.src = w[n].host + "/s.js";
+    j.src = w[n].host + "/chatplugin/ui/s.js";
     f.parentNode.insertBefore(j, f);
   })(window, document, "script", "airy");
 </script>

--- a/docs/docs/sources/facebook.md
+++ b/docs/docs/sources/facebook.md
@@ -27,6 +27,14 @@ Core Platform instance.
 
 :::
 
+:::note
+
+The Facebook Messenger source is not enabled by default.
+
+You need to add configuration in your airy.yaml file and apply it to activate it.
+
+:::
+
 ## Configuration
 
 The Facebook source requires the following configuration:

--- a/docs/docs/sources/google.md
+++ b/docs/docs/sources/google.md
@@ -26,6 +26,14 @@ Business Location and your running instance of Airy Core.
 
 :::
 
+:::note
+
+The Google's Business Messages source is not enabled by default.
+
+You need to add configuration in your airy.yaml file and apply it to activate it.
+
+:::
+
 ## Configuration
 
 Google's Business Messages requires the following configuration:

--- a/docs/docs/sources/sms-twilio.md
+++ b/docs/docs/sources/sms-twilio.md
@@ -27,6 +27,14 @@ The Twilio SMS source provides a channel for sending and receiving SMS using the
 
 :::
 
+:::note
+
+The SMS via Twilio source is not enabled by default.
+
+You need to add configuration in your airy.yaml file and apply it to activate it.
+
+:::
+
 ## Configuration
 
 import TwilioConfig from './twilio-config.mdx'

--- a/docs/docs/sources/whatsapp-twilio.md
+++ b/docs/docs/sources/whatsapp-twilio.md
@@ -23,6 +23,14 @@ messages using the [Twilio API](https://www.twilio.com/).
 
 :::
 
+:::note
+
+The WhatsApp via Twilio source is not enabled by default.
+
+You need to add configuration in your airy.yaml file and apply it to activate it.
+
+:::
+
 ## Configuration
 
 import TwilioConfig from './twilio-config.mdx'

--- a/docs/docs/ui/inbox.md
+++ b/docs/docs/ui/inbox.md
@@ -16,6 +16,14 @@ See all conversations from the sources you connected, regardless of whether they
 
 The inbox supports not only text messages but a variety of different message types.
 
+:::warning
+
+Authentication is disabled by default in the Inbox UI component of `Airy Core`.
+
+As this is suitable **only for testing purposes**, we advise you to refer to our [Authentication configuration section](/getting-started/installation/security).
+
+:::
+
 ## Message Types
 
 **Send & Receive Messages**

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -10,6 +10,7 @@ module.exports = {
             'getting-started/installation/minikube',
             'getting-started/installation/aws',
             'getting-started/installation/configuration',
+            'getting-started/installation/security',
           ],
         },
         {
@@ -42,7 +43,6 @@ module.exports = {
     {
       '🔌 API': [
         'api/introduction',
-        'api/authentication',
         {
           'HTTP Endpoints': [
             'api/endpoints/introduction',

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -7,7 +7,7 @@
   --ifm-color-primary-lighter: #5a91ea;
   --ifm-color-primary-lightest: #80aaef;
 
-  --ifm-color-danger: #ff6188;
+  --ifm-color-danger: #fcc934;
   --ifm-color-danger-dark: #ff3e6d;
   --ifm-color-danger-darker: #ff2c60;
   --ifm-color-danger-darkest: #f6003d;


### PR DESCRIPTION
- Added disclamer in sources
- The code block doesn't fit well in the `per-source-docs` I think, I think it is more clear in the example in the Configuration document
- Flow of reading slightly changed - Install CLI -> Install Airy using the CLI -> Get started (example with one source or link to other sources)
- Added a "Secure your installation" block in AWS
- Removed the `self-signed certificate` section
- Added warnings and links to the Authentication section from AWS and the Inbox.
- Code updated for the chatplugin installation.
