### PR TITLE
Revert "[#1939] Redirect root request to /ui"

### DIFF
--- a/infrastructure/helm-chart/templates/ingress-ui.yaml
+++ b/infrastructure/helm-chart/templates/ingress-ui.yaml
@@ -18,20 +18,6 @@ spec:
                 name: frontend-ui
                 port:
                   number: 80
-          - path: /ui/login
-            pathType: Prefix
-            backend:
-              service:
-                name: frontend-ui
-                port:
-                  number: 80
-          - path: "/"
-            pathType: Exact
-            backend:
-              service:
-                name: frontend-ui
-                port:
-                  number: 80
           - path: /chatplugin/ui
             pathType: Prefix
             backend:


### PR DESCRIPTION
Reverts airyhq/airy#1940

The fallback conflicts with other routes leading to a broken authentication behavior