### PR TITLE
Change endpoint for webhook to /twilio

### DIFF
--- a/docs/docs/sources/twilio-sources.mdx
+++ b/docs/docs/sources/twilio-sources.mdx
@@ -47,13 +47,13 @@ https://www.twilio.com/console/phone-numbers
 Your Twilio Webhook URL should have the following format:
 
 ```
-https://your-public-fqdn/facebook
+https://your-public-fqdn/twilio
 ```
 
 or if you are using Ngrok:
 
 ```
-https://RANDOM_STRING.tunnel.airy.co/facebook
+https://RANDOM_STRING.tunnel.airy.co/twilio
 ```
 
 :::


### PR DESCRIPTION
In twilio-sources.mdx the Twilio Webhook URL endpoint was`/facebook` instead of `/twilio` which resulted in a 404. Just changed the endpoint to be the right one. 