### PR TITLE
[#1212] HTTPS inside Kubernetes

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
-	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/TwinProduction/go-color v1.0.0
 	github.com/airyhq/airy/lib/go/httpclient v0.0.0
 	github.com/aws/aws-sdk-go v1.37.29

--- a/cli/pkg/cmd/create/create.go
+++ b/cli/pkg/cmd/create/create.go
@@ -93,7 +93,7 @@ func create(cmd *cobra.Command, args []string) {
 		console.Exit("installing Helm charts failed with err: ", err)
 	}
 
-	if err = provider.PostInstallation(dir); err != nil {
+	if err = provider.PostInstallation(providerConfig, dir); err != nil {
 		console.Exit("failed to run post installation hook: ", err)
 	}
 

--- a/cli/pkg/providers/aws/aws.go
+++ b/cli/pkg/providers/aws/aws.go
@@ -49,42 +49,45 @@ func (p *provider) GetOverrides() tmpl.Variables {
 	}
 }
 
-func (p *provider) PostInstallation(dir workspace.ConfigDir) error {
-	conf, err := dir.LoadAiryYaml()
-	if err != nil {
-		return err
-	}
+func (p *provider) PostInstallation(providerConfig map[string]string, dir workspace.ConfigDir) error {
+	if providerConfig["hostUpdate"] != "false" {
+		conf, err := dir.LoadAiryYaml()
+		if err != nil {
+			return err
+		}
 
-	clientset, err := p.context.GetClientSet()
-	if err != nil {
-		return err
-	}
+		clientset, err := p.context.GetClientSet()
+		if err != nil {
+			return err
+		}
 
-	ingressService, err := clientset.CoreV1().Services("kube-system").Get(context.TODO(), "traefik", metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
+		ingressService, err := clientset.CoreV1().Services("kube-system").Get(context.TODO(), "traefik", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
 
-	loadBalancerUrl := ingressService.Status.LoadBalancer.Ingress[0].Hostname
+		loadBalancerUrl := ingressService.Status.LoadBalancer.Ingress[0].Hostname
 
-	if err = p.updateIngress("airy-core", loadBalancerUrl, conf.Kubernetes.Namespace); err != nil {
-		return err
-	}
-	if err = p.updateIngress("airy-core-ui", loadBalancerUrl, conf.Kubernetes.Namespace); err != nil {
-		return err
-	}
-	if err = p.updateIngress("airy-core-redirect", loadBalancerUrl, conf.Kubernetes.Namespace); err != nil {
-		return err
-	}
+		if err = p.updateIngress("airy-core", loadBalancerUrl, conf.Kubernetes.Namespace); err != nil {
+			return err
+		}
+		if err = p.updateIngress("airy-core-ui", loadBalancerUrl, conf.Kubernetes.Namespace); err != nil {
+			return err
+		}
+		if err = p.updateIngress("airy-core-redirect", loadBalancerUrl, conf.Kubernetes.Namespace); err != nil {
+			return err
+		}
 
-	if err = p.updateHostsConfigMap(loadBalancerUrl, conf.Kubernetes.Namespace); err != nil {
-		return err
-	}
+		if err = p.updateHostsConfigMap(loadBalancerUrl, conf.Kubernetes.Namespace); err != nil {
+			return err
+		}
 
-	return dir.UpdateAiryYaml(func(conf workspace.AiryConf) workspace.AiryConf {
-		conf.Kubernetes.Host = loadBalancerUrl
-		return conf
-	})
+		return dir.UpdateAiryYaml(func(conf workspace.AiryConf) workspace.AiryConf {
+			conf.Kubernetes.Host = loadBalancerUrl
+			return conf
+		})
+	}
+	return nil
 }
 
 type KubeConfig struct {

--- a/cli/pkg/providers/minikube/minikube.go
+++ b/cli/pkg/providers/minikube/minikube.go
@@ -35,7 +35,7 @@ func New(w io.Writer) *provider {
 func (p *provider) GetOverrides() template.Variables {
 	return template.Variables{
 		NgrokEnabled: true,
-		Host:         "http://airy.core",
+		Host:         "airy.core",
 	}
 }
 
@@ -97,7 +97,7 @@ func getCmd(args ...string) *exec.Cmd {
 	return exec.Command(minikube, append(defaultArgs, args...)...)
 }
 
-func (p *provider) PostInstallation(dir workspace.ConfigDir) error {
+func (p *provider) PostInstallation(providerConfig map[string]string, dir workspace.ConfigDir) error {
 	conf, err := dir.LoadAiryYaml()
 	if err != nil {
 		return err

--- a/cli/pkg/providers/provider.go
+++ b/cli/pkg/providers/provider.go
@@ -20,7 +20,7 @@ const (
 type Provider interface {
 	Provision(providerConfig map[string]string, dir workspace.ConfigDir) (kube.KubeCtx, error)
 	GetOverrides() template.Variables
-	PostInstallation(dir workspace.ConfigDir) error
+	PostInstallation(providerConfig map[string]string, dir workspace.ConfigDir) error
 }
 
 func MustGet(providerName ProviderName, w io.Writer) Provider {

--- a/cli/pkg/workspace/airy_yaml.go
+++ b/cli/pkg/workspace/airy_yaml.go
@@ -6,13 +6,15 @@ type KubernetesConf struct {
 	Namespace               string            `yaml:"namespace"`
 	NgrokEnabled            string            `yaml:"ngrokEnabled"`
 	Host                    string            `yaml:"host"`
+	Https                   string            `yaml:"https,omitempty`
 	LoadbalancerAnnotations map[string]string `yaml:"loadbalancerAnnotations,omitempty"`
+	LetsencryptEmail        string            `yaml:"letsencryptEmail,omitempty`
 }
 
 type componentsConf map[string]map[string]string
 
 type AiryConf struct {
-	Kubernetes KubernetesConf			 `yaml:"kubernetes"`
+	Kubernetes KubernetesConf            `yaml:"kubernetes"`
 	Security   SecurityConf              `yaml:"security"`
 	Components map[string]componentsConf `yaml:"components,omitempty"`
 }

--- a/cli/pkg/workspace/template/copy.go
+++ b/cli/pkg/workspace/template/copy.go
@@ -16,6 +16,8 @@ type Variables struct {
 	Namespace               string
 	Host                    string
 	LoadbalancerAnnotations map[string]string
+	Https                   bool
+	LetsencryptEmail        string
 }
 
 //go:embed src

--- a/cli/pkg/workspace/template/src/airy.yaml
+++ b/cli/pkg/workspace/template/src/airy.yaml
@@ -4,14 +4,20 @@ kubernetes:
   namespace: {{ .Namespace }}
   ngrokEnabled: {{ default "false" .NgrokEnabled }}
 {{- if .Host }}
-  host: {{ default "http://airy.core" .Host }}
+  host: {{ default "airy.core" .Host }}
 {{- end }}
-{{- if .LoadbalancerAnnotations }}
+ingress:
+  https: {{ default "false" .Https}}
+  letsencryptEmail: {{ .LetsencryptEmail}}
+  {{- if .LoadbalancerAnnotations }}
   loadbalancerAnnotations:
   {{- range $k, $v := .LoadbalancerAnnotations }}
     {{ $k }}: {{ $v }}
   {{- end }}
-{{- end }}
+  {{- end }}
 security:
   allowedOrigins: "*"
   jwtSecret: {{ randAlphaNum 128 }}
+components:
+  sources:
+  integration:

--- a/docs/docs/getting-started/installation/aws.md
+++ b/docs/docs/getting-started/installation/aws.md
@@ -73,9 +73,9 @@ Download and install the [Airy CLI](cli/introduction.md).
 Export your AWS_PROFILE and AWS_REGION as described in the [AWS
 documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html).
 
-:::note
+:::warning
 
-If you want to use Airy Core with Let's Encrypt, refer to the [Let's Encrypt section](https://docs.airy.co/getting-started/installation/aws#https-using-lets-encrypt) for customizing your `airy.yaml` file before proceeding.
+If you want to use Airy Core with auto-generated HTTPS certificates, refer to the [Let's Encrypt section](/getting-started/installation/aws#https-using-lets-encrypt) for customizing your `airy.yaml` file before proceeding.
 
 :::
 

--- a/docs/docs/getting-started/installation/aws.md
+++ b/docs/docs/getting-started/installation/aws.md
@@ -271,7 +271,7 @@ kubectl get --namespace kube-system service traefik --output jsonpath='{.status.
 
 #### Start the ingress controller
 
-If the ingress controller is started before the DNS record is added, the Let's Encrypt servers will block an throttle the registration attempts. That is why we recommend starting the ingress controller after the DNS record is added.
+If the ingress controller is started before the DNS record is added, the Let's Encrypt servers will block and throttle the registration attempts. That is why we recommend starting the ingress controller after the DNS record is added.
 
 ```sh
 kubectl -n kube-system scale statefulset -l k8s-app=traefik-ingress-lb --replicas=1

--- a/docs/docs/getting-started/installation/aws.md
+++ b/docs/docs/getting-started/installation/aws.md
@@ -73,6 +73,12 @@ Download and install the [Airy CLI](cli/introduction.md).
 Export your AWS_PROFILE and AWS_REGION as described in the [AWS
 documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html).
 
+:::note
+
+If you want to use Airy Core with Let's Encrypt, refer to the [Let's Encrypt section](https://docs.airy.co/getting-started/installation/aws#https-using-lets-encrypt) for customizing your `airy.yaml` file before proceeding.
+
+:::
+
 Now you can run this command, which will create `Airy Core` in your AWS account:
 
 ```bash
@@ -148,7 +154,7 @@ As this is intended **only for testing purposes**, `it is mandatory that you to 
 
 To enable authenticaiton to the API and in the UI, refer to our [Authentication configuration section](/getting-started/installation/security)
 
-### Enable HTTPS
+### HTTPS with existing certificates
 
 This section guides you through the necessary steps to configure HTTPS on your `Airy Core` instance.
 
@@ -173,8 +179,6 @@ After the certificate has been uploaded to AWS ACM, you will need the unique ARN
 :::note
 
 If you don't have your own HTTPS certificate you can request one from AWS ACM.
-
-If you want to use Let's Encrypt, have a look at the [Following Traefik ingress guide](https://doc.traefik.io/traefik/v2.0/user-guides/crd-acme/) on how to integrate the HTTPS certificates with the installed ingress controller.
 
 :::
 
@@ -224,6 +228,56 @@ At this point, the frontend and the API services of `Airy Core` should be access
 ```sh
 airy api endpoint
 ```
+
+### HTTPS using Let's Encrypt
+
+You can customize your installation of `Airy Core` to install a custom Traefik ingress controller which has an enabled `Let's Encrypt` capability. The ingress controller will register and renew the certificates for you automatically.
+
+#### Customize your Airy Core installation
+
+To customize your Airy Core installation, you need to create an initial config file using the following command
+
+```sh
+airy create --provider aws --init-only
+```
+
+Then edit your `airy.yaml` file and add the following configuration
+
+```sh
+kubernetes:
+  host: myairy.myhostname.com
+ingress:
+  https: true
+  letsencryptEmail: "mymail@myhostname.com"
+
+```
+
+The `kubernets.host` value should be set to your desired hostname. Configure the e-mail address you want to use for your Let's Encrypt registration under `ingress.letsencryptEmail`.
+
+After setting these parameters, create your `Airy Core` instance with the following option:
+
+```sh
+airy create --provider aws --provider-config hostUpdate=false
+```
+
+#### Setup your DNS
+
+You should create a CNAME DNS record for the hostname that you set under `kubernetes.host` in the previous step to point to the hostname of the LoadBalancer, created by AWS for the ingress service:
+
+```sh
+export KUBECONFIG="PATH/TO/DIR/kube.conf"
+kubectl get --namespace kube-system service traefik --output jsonpath='{.status.loadBalancer.ingress[0].hostname}{"\n"}'
+```
+
+#### Start the ingress controller
+
+If the ingress controller is started before the DNS record is added, the Let's Encrypt servers will block an throttle the registration attempts. That is why we recommend starting the ingress controller after the DNS record is added.
+
+```sh
+kubectl -n kube-system scale statefulset -l k8s-app=traefik-ingress-lb --replicas=1
+```
+
+After this, your `Airy Core` will be reachable under HTTPS and on your desired hostname (for example https://myairy.myhostname.com).
 
 ## Integrate public webhooks
 

--- a/docs/docs/getting-started/installation/configuration.md
+++ b/docs/docs/getting-started/installation/configuration.md
@@ -37,7 +37,7 @@ are looking for.
 
 - `namespace` the Kubernetes namespace that the **Airy Core** will use
 
-- `ingress` the subdomains for the **Airy Components** that need to be accessed from outside the Kubernetes cluster
+- `host` the hostname which will be used to access your `Airy Core` instance, outside of the Kubernetes cluster (default: airy.core)
 
 ### Prerequisites
 
@@ -49,6 +49,14 @@ cluster and Redis.
   - `brokers` comma separated list of the broker endpoints
   - `schema-registry` url to the Schema Registry
   - `commitInterval` the [Kafka Commit Interval](https://kafka.apache.org/documentation/#consumerconfigs_auto.commit.interval.ms) if you are using the included Helm chart
+
+### Ingress
+
+- `ingress`
+
+  - `https` set to `true` to enable HTTPS
+  - `loadbalancerAnnotations` list of annotations used to configure the LoadBalancer pointing to the ingress controller, in cloud environment (for AWS the following annotation is added by default: `service.beta.kubernetes.io/aws-load-balancer-type: nlb` )
+  - `letsencryptEmail` the e-mail address used for Let's Encrypt registration, when using HTTPS.
 
 ### Security
 

--- a/infrastructure/helm-chart/charts/ingres/Chart.yaml
+++ b/infrastructure/helm-chart/charts/ingres/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Airy Platform networking resources
+name: ingress
+version: 1.0

--- a/infrastructure/helm-chart/charts/ingres/templates/ingress-controller-http.yaml
+++ b/infrastructure/helm-chart/charts/ingres/templates/ingress-controller-http.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.global.ingress }}
+{{ if not .Values.global.ingress.https }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -86,7 +88,7 @@ metadata:
   name: traefik
   namespace: kube-system
   annotations:
-  {{- range $k, $v := .Values.global.kubernetes.loadbalancerAnnotations }}
+  {{- range $k, $v := .Values.global.ingress.loadbalancerAnnotations }}
     {{ $k }}: {{ $v }}
   {{- end }}
 spec:
@@ -98,3 +100,5 @@ spec:
       targetPort: 80
       name: web
   type: LoadBalancer
+{{ end }}
+{{ end }}

--- a/infrastructure/helm-chart/charts/ingres/templates/ingress-controller-https-letsencrypt.yaml
+++ b/infrastructure/helm-chart/charts/ingres/templates/ingress-controller-https-letsencrypt.yaml
@@ -1,0 +1,162 @@
+{{ if .Values.global.ingress }}
+{{ if .Values.global.ingress.https }}
+{{ if .Values.global.ingress.letsencryptEmail }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: traefik-ingress-controller
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: traefik-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: traefik-ingress-controller
+subjects:
+  - kind: ServiceAccount
+    name: traefik-ingress-controller
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: traefik-ingress-controller
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: traefik-ingress-controller
+  namespace: kube-system
+  labels:
+    k8s-app: traefik-ingress-lb
+spec:
+  serviceName: traefik-ingress-lb
+  replicas: 0
+  selector:
+    matchLabels:
+      app: traefik-ingress-lb
+      k8s-app: traefik-ingress-lb
+  template:
+    metadata:
+      labels:
+        app: traefik-ingress-lb
+        name: traefik-ingress-lb
+        k8s-app: traefik-ingress-lb
+    spec:
+      serviceAccountName: traefik-ingress-controller
+      terminationGracePeriodSeconds: 60
+      containers:
+        - image: traefik:v1.7
+          name: traefik-ingress-lb
+          imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: "/config"
+              name: "config"
+            - mountPath: "/acme"
+              name: "acme"
+          ports:
+            - containerPort: 80
+              name: http
+            - containerPort: 443
+              name: https
+            - containerPort: 8080
+              name: admin
+          args:
+            - --api
+            - --kubernetes
+            - --logLevel=INFO
+            - --configfile=/config/traefik.toml
+      volumes:
+        - name: config
+          configMap:
+            name: traefik-conf
+        - name: acme
+          emptyDir: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: acme
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Mi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: traefik-conf
+  namespace: kube-system
+data:
+  traefik.toml: |
+    # traefik.toml
+    defaultEntryPoints = ["http","https"]
+    [entryPoints]
+      [entryPoints.http]
+      address = ":80"
+      [entryPoints.http.redirect]
+      entryPoint = "https"
+      [entryPoints.https]
+      address = ":443"
+      [entryPoints.https.tls]
+    [acme]
+      email = "{{ .Values.global.ingress.letsencryptEmail }}"
+      storage = "/acme/acme.json"
+      entryPoint = "https"
+      onHostRule = true
+      acmeLogging = true
+      [acme.httpChallenge]
+        entryPoint = "http"
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: traefik
+  namespace: kube-system
+  annotations:
+  {{- range $k, $v := .Values.global.ingress.loadbalancerAnnotations }}
+    {{ $k }}: {{ $v }}
+  {{- end }}
+spec:
+  selector:
+    k8s-app: traefik-ingress-lb
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+      name: http
+    - protocol: TCP
+      port: 443
+      targetPort: 443
+      name: https
+  type: LoadBalancer
+{{ end }}
+{{ end }}
+{{ end }}

--- a/infrastructure/helm-chart/charts/ingres/values.yaml
+++ b/infrastructure/helm-chart/charts/ingres/values.yaml
@@ -1,0 +1,3 @@
+https: false
+loadbalancerAnnotations: {}
+letsencryptEmail:

--- a/infrastructure/helm-chart/charts/tools/charts/ahkq/templates/ingress.yaml
+++ b/infrastructure/helm-chart/charts/tools/charts/ahkq/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     kubernetes.io/ingress.class: traefik
 spec:
   rules:
-    - host: {{ get (urlParse .Values.global.kubernetes.host) "host" }}
+    - host: {{ .Values.global.kubernetes.host }}
       http:
         paths:
           - path: /tools/akhq

--- a/infrastructure/helm-chart/templates/configmap.yaml
+++ b/infrastructure/helm-chart/templates/configmap.yaml
@@ -4,7 +4,15 @@ metadata:
   name: hostnames
   namespace: {{ .Values.global.kubernetes.namespace }}
 data:
-  HOST: {{ .Values.global.kubernetes.host }}
+  {{ if .Values.global.ingress }}
+   {{ if .Values.global.ingress.https }}
+  HOST: https://{{ .Values.global.kubernetes.host }}
+   {{ else }}
+  HOST: http://{{ .Values.global.kubernetes.host }}
+   {{ end }}
+  {{ else }}
+  HOST: http://{{ .Values.global.kubernetes.host }}
+  {{ end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/infrastructure/helm-chart/templates/ingress-ui.yaml
+++ b/infrastructure/helm-chart/templates/ingress-ui.yaml
@@ -8,7 +8,7 @@ metadata:
     traefik.frontend.rule.type: PathPrefixStrip
 spec:
   rules:
-    - host: {{ get (urlParse .Values.global.kubernetes.host) "host" }}
+    - host: {{ .Values.global.kubernetes.host }}
       http:
         paths:
           - path: /ui
@@ -35,7 +35,7 @@ metadata:
     kubernetes.io/ingress.class: "traefik"
 spec:
   rules:
-    - host: {{ get (urlParse .Values.global.kubernetes.host) "host" }}
+    - host: {{ .Values.global.kubernetes.host }}
       http:
         paths:
           - path: /

--- a/infrastructure/helm-chart/templates/ingress.yaml
+++ b/infrastructure/helm-chart/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Values.global.kubernetes.namespace }}
 spec:
   rules:
-    - host: {{ get (urlParse .Values.global.kubernetes.host) "host" }}
+    - host: {{ .Values.global.kubernetes.host }}
       http:
         paths:
           - path: /ws.communication

--- a/infrastructure/helm-chart/values.yaml
+++ b/infrastructure/helm-chart/values.yaml
@@ -1,4 +1,3 @@
 global:
   kubernetes:
-    host: "http://airy.core"
-    loadbalancerAnnotations: {}
+    host: "airy.core"


### PR DESCRIPTION
- Added option for helm to deploy with letsencrypt.
- After creation, the ingress controller reads the `host` entries in the `ingress` resources and creates the letsencrypt certificates.
- Letsencrypt doesn't work with the loadbalancer url, because the url is very long.

Potential usage:
- Run `airy create`
- Add DNS entry for `myairy.mydomain.com` -> created loadbalancer
- Patch the ingress resources
```
for ingress in $(kubectl get ingress --no-headers -o custom-columns=":metadata.name"); do kubectl get ingress ${ingress} -o json |  jq '(.spec.rules[0].host="myairy.mydomain.com")' | kubectl apply -f -; done
```

And the letsencrypt certificates are created. Also redirect from https to http is configured.