### PR TITLE
[#2243] Introduce airy upgrade

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/TwinProduction/go-color v1.0.0
+	github.com/airyhq/airy/infrastructure/lib/go/k8s/util v0.0.0-20210813123122-f26352d78a88
 	github.com/airyhq/airy/lib/go/httpclient v0.0.0
 	github.com/aws/aws-sdk-go v1.37.29
 	github.com/aws/aws-sdk-go-v2/config v1.1.1

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -37,6 +37,9 @@ github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/TwinProduction/go-color v1.0.0 h1:8n59tqmLmt8jyRsY44RPy2ixPDDw0FcVoAhlYeyz3Jw=
 github.com/TwinProduction/go-color v1.0.0/go.mod h1:5hWpSyT+mmKPjCwPNEruBW5Dkbs/2PwOuU468ntEXNQ=
+github.com/airyhq/airy v0.0.0-20210813123122-f26352d78a88 h1:fBAxo6dTPEjubBcEkidXL22306FmpasAY+6ewNZPWdM=
+github.com/airyhq/airy/infrastructure/lib/go/k8s/util v0.0.0-20210813123122-f26352d78a88 h1:3lw6BB3Qvbjnd67rs2BZodQV1PD1FmWqvTBJR7zPTfI=
+github.com/airyhq/airy/infrastructure/lib/go/k8s/util v0.0.0-20210813123122-f26352d78a88/go.mod h1:YgaeqllGAjZ7AgtktlRrtSPsy/2rXJijMIFFuibxenk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -523,6 +526,8 @@ k8s.io/apimachinery v0.19.0/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlm
 k8s.io/client-go v0.19.0 h1:1+0E0zfWFIWeyRhQYWzimJOyAk2UT7TiARaLNwJCf7k=
 k8s.io/client-go v0.19.0/go.mod h1:H9E/VT95blcFQnlyShFgnFT9ZnJOAceiUHM3MlRC+mU=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
+k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0 h1:XRvcwJozkgZ1UQJmfMGpvRthQHOvihEhYtDfAaxMz/A=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/cli/integration/golden/cli.no-args.golden
+++ b/cli/integration/golden/cli.no-args.golden
@@ -10,6 +10,7 @@ Available Commands:
   help        Help about any command
   status      Reports the status of an Airy Core instance
   ui          Opens the Airy Core UI in your local browser
+  upgrade     Upgrades an instance of Airy Core
   version     Prints version information
 
 Flags:

--- a/cli/pkg/cmd/BUILD
+++ b/cli/pkg/cmd/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//cli/pkg/cmd/create",
         "//cli/pkg/cmd/status",
         "//cli/pkg/cmd/ui",
+        "//cli/pkg/cmd/upgrade",
         "//cli/pkg/workspace",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_spf13_viper//:viper",

--- a/cli/pkg/cmd/create/create.go
+++ b/cli/pkg/cmd/create/create.go
@@ -3,6 +3,7 @@ package create
 import (
 	"cli/pkg/cmd/config"
 	"cli/pkg/console"
+	"cli/pkg/helm"
 	"cli/pkg/kube"
 	"cli/pkg/providers"
 	"cli/pkg/workspace"
@@ -82,7 +83,7 @@ func create(cmd *cobra.Command, args []string) {
 		console.Exit("could not store the kube context: ", err)
 	}
 
-	helm := New(clientset, version, namespace, dir.GetAiryYaml())
+	helm := helm.New(clientset, version, namespace, dir.GetAiryYaml())
 	if err := helm.Setup(); err != nil {
 		console.Exit("setting up Helm failed with err: ", err)
 	}

--- a/cli/pkg/cmd/root.go
+++ b/cli/pkg/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"cli/pkg/cmd/create"
 	"cli/pkg/cmd/status"
 	"cli/pkg/cmd/ui"
+	"cli/pkg/cmd/upgrade"
 	"cli/pkg/workspace"
 	"fmt"
 	"os"
@@ -62,4 +63,5 @@ func init() {
 	RootCmd.AddCommand(ui.UICmd)
 	RootCmd.AddCommand(versionCmd)
 	RootCmd.AddCommand(create.CreateCmd)
+	RootCmd.AddCommand(upgrade.UpgradeCmd)
 }

--- a/cli/pkg/cmd/upgrade/BUILD
+++ b/cli/pkg/cmd/upgrade/BUILD
@@ -2,14 +2,12 @@ load("@com_github_airyhq_bazel_tools//lint:buildifier.bzl", "check_pkg")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "create",
-    srcs = [
-        "create.go",
-    ],
-    importpath = "cli/pkg/cmd/create",
+    name = "upgrade",
+    srcs = ["upgrade.go"],
+    importpath = "cli/pkg/cmd/upgrade",
     visibility = ["//visibility:public"],
     x_defs = {
-        "version": "{STABLE_VERSION}",
+        "Version": "{STABLE_VERSION}",
     },
     deps = [
         "//cli/pkg/cmd/config",
@@ -18,6 +16,7 @@ go_library(
         "//cli/pkg/kube",
         "//cli/pkg/providers",
         "//cli/pkg/workspace",
+        "//infrastructure/lib/go/k8s/util",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_spf13_viper//:viper",
         "@com_github_twinproduction_go_color//:go-color",

--- a/cli/pkg/cmd/upgrade/upgrade.go
+++ b/cli/pkg/cmd/upgrade/upgrade.go
@@ -1,0 +1,101 @@
+package upgrade
+
+import (
+	"cli/pkg/cmd/config"
+	"cli/pkg/console"
+	"cli/pkg/helm"
+	"cli/pkg/kube"
+	"cli/pkg/workspace"
+	"fmt"
+
+	"github.com/airyhq/airy/infrastructure/lib/go/k8s/util"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	approve    bool
+	version    string
+	Version    string
+	UpgradeCmd = &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrades an instance of Airy Core",
+		Long:  `Upgrades an existing Airy Core instance, read from a workspace directory (default .)`,
+		Args:  cobra.MaximumNArgs(1),
+		Run:   upgrade,
+	}
+)
+
+func init() {
+	UpgradeCmd.Flags().StringVar(&version, "version", "", "Specify a version to upgrade to (optional).")
+	UpgradeCmd.Flags().BoolVar(&approve, "approve", false, "Upgrade automatically without asking for an approval (optional).")
+}
+
+func upgrade(cmd *cobra.Command, args []string) {
+	autoApprove, _ := cmd.Flags().GetBool("approve")
+	workspacePath, err := cmd.Flags().GetString("workspace")
+	if err != nil {
+		console.Exit("Unable to find suitable workspace :", err)
+	}
+	dir := workspace.Init(workspacePath)
+	kubeCtx := kube.Load()
+	clientset, err := kubeCtx.GetClientSet()
+	namespace := viper.GetString("namespace")
+	if err != nil {
+		console.Exit("Could not find an installation of Airy Core. Get started here https://airy.co/docs/core/getting-started/installation/introduction")
+	}
+
+	if version == "" {
+		version = Version
+	}
+	clusterAiryConf, err := kube.GetDeployedAiryYaml(namespace, clientset)
+	if err != nil {
+		console.Exit("Unable to retrieve existing version of Airy Core: ", err.Error())
+	}
+	oldVersion := clusterAiryConf.Kubernetes.AppImageTag
+
+	fmt.Println("CLI version: ", Version)
+	fmt.Println("Current Airy Core version: ", oldVersion)
+	fmt.Println("New Airy Core version: ", version)
+	fmt.Println()
+
+	if autoApprove != true {
+		if util.ConfirmToProceed() == false {
+			console.Exit("Upgrade aborted.")
+		}
+	}
+
+	fmt.Println("Upgrading the helm charts of Airy Core...")
+	helm := helm.New(clientset, version, namespace, dir.GetAiryYaml())
+	if cmErr := helm.UpsertAiryConfigMap(); cmErr != nil {
+		console.Exit("Unable to copy config file into Airy Core :", cmErr)
+	}
+	if upgradeErr := helm.UpgradeCharts(); upgradeErr != nil {
+		fmt.Println("Upgrading the Helm Charts failed with err: ", upgradeErr)
+		fmt.Println("Attempting to roll back the upgrade...")
+		if rollBackErr := helm.RollBackUpgrade(oldVersion); rollBackErr != nil {
+			console.Exit("Roll Back of the upgrade failed with err: ", rollBackErr)
+		}
+		console.Exit("The roll back of the upgrade was successful.")
+	}
+
+	fmt.Println("Applying config from the configuration file.")
+	config.ApplyConfig(workspacePath)
+
+	fmt.Println(("Writing the new version into the configuration file."))
+	if writeVersionErr := dir.UpdateAiryYaml(func(conf workspace.AiryConf) workspace.AiryConf {
+		conf.Kubernetes.AppImageTag = version
+		return conf
+	}); writeVersionErr != nil {
+		console.Exit("Writing the version into config file failed with err: ", writeVersionErr)
+	}
+
+	fmt.Println("Copying the configuration file in the Airy Core K8s cluster.")
+	if cmErr := helm.UpsertAiryConfigMap(); cmErr != nil {
+		console.Exit("Unable to copy config file into Airy Core.")
+	}
+
+	fmt.Println("✅ Airy Core upgraded")
+	fmt.Println()
+}

--- a/cli/pkg/helm/BUILD
+++ b/cli/pkg/helm/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "helm",
+    srcs = ["helm.go"],
+    importpath = "cli/pkg/helm",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cli/pkg/kube",
+        "@io_k8s_api//batch/v1:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_api//rbac/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/watch:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
+    ],
+)

--- a/cli/pkg/kube/BUILD
+++ b/cli/pkg/kube/BUILD
@@ -10,7 +10,9 @@ go_library(
     importpath = "cli/pkg/kube",
     visibility = ["//visibility:public"],
     deps = [
+        "//cli/pkg/workspace",
         "@com_github_spf13_viper//:viper",
+        "@in_gopkg_yaml_v2//:yaml_v2",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",

--- a/cli/pkg/kube/configmaps.go
+++ b/cli/pkg/kube/configmaps.go
@@ -1,8 +1,12 @@
 package kube
 
 import (
+	"cli/pkg/workspace"
 	"context"
+
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -15,7 +19,7 @@ func ApplyConfigMap(configmapName string, namespace string, cmData map[string]st
 				ObjectMeta: v1.ObjectMeta{
 					Name:      configmapName,
 					Namespace: namespace,
-					Labels: labels,
+					Labels:    labels,
 				},
 				Data: cmData,
 			}, v1.CreateOptions{})
@@ -30,8 +34,32 @@ func ApplyConfigMap(configmapName string, namespace string, cmData map[string]st
 func DeleteConfigMap(configmapName string, namespace string, clientset *kubernetes.Clientset) error {
 	cm, _ := clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configmapName, v1.GetOptions{})
 	if cm.GetName() != "" {
-		err := clientset.CoreV1().ConfigMaps(namespace).Delete(context.TODO(),configmapName, v1.DeleteOptions{})
+		err := clientset.CoreV1().ConfigMaps(namespace).Delete(context.TODO(), configmapName, v1.DeleteOptions{})
 		return err
 	}
 	return nil
+}
+
+func GetCmData(configmapName string, namespace string, clientset *kubernetes.Clientset) (map[string]string, error) {
+	configMaps := clientset.CoreV1().ConfigMaps(namespace)
+
+	configMap, err := configMaps.Get(context.TODO(), configmapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return configMap.Data, nil
+}
+
+func GetDeployedAiryYaml(namespace string, clientset *kubernetes.Clientset) (workspace.AiryConf, error) {
+	airyYaml, err := GetCmData("airy-config-map", namespace, clientset)
+	if err != nil {
+		return workspace.AiryConf{}, err
+	}
+	deployedAiryYaml := workspace.HelmAiryConf{}
+	err = yaml.Unmarshal([]byte(airyYaml["airy-config-map.yaml"]), &deployedAiryYaml)
+	if err != nil {
+		return workspace.AiryConf{}, err
+	}
+	return deployedAiryYaml.Global, nil
 }

--- a/cli/pkg/workspace/airy_yaml.go
+++ b/cli/pkg/workspace/airy_yaml.go
@@ -1,22 +1,17 @@
 package workspace
 
 type KubernetesConf struct {
-	AppImageTag             string            `yaml:"appImageTag"`
-	ContainerRegistry       string            `yaml:"containerRegistry"`
-	Namespace               string            `yaml:"namespace"`
-	NgrokEnabled            string            `yaml:"ngrokEnabled"`
-	Host                    string            `yaml:"host"`
-	Https                   string            `yaml:"https,omitempty`
-	LoadbalancerAnnotations map[string]string `yaml:"loadbalancerAnnotations,omitempty"`
-	LetsencryptEmail        string            `yaml:"letsencryptEmail,omitempty`
+	AppImageTag       string `yaml:"appImageTag"`
+	ContainerRegistry string `yaml:"containerRegistry"`
+	Namespace         string `yaml:"namespace"`
+	NgrokEnabled      bool   `yaml:"ngrokEnabled"`
+	Host              string `yaml:"host"`
 }
 
-type componentsConf map[string]map[string]string
-
-type AiryConf struct {
-	Kubernetes KubernetesConf            `yaml:"kubernetes"`
-	Security   SecurityConf              `yaml:"security"`
-	Components map[string]componentsConf `yaml:"components,omitempty"`
+type IngressConf struct {
+	Https                   bool              `yaml:"https,omitempty"`
+	LetsencryptEmail        string            `yaml:"letsencryptEmail,omitempty"`
+	LoadbalancerAnnotations map[string]string `yaml:"loadbalancerAnnotations,omitempty"`
 }
 
 type SecurityConf struct {
@@ -24,4 +19,16 @@ type SecurityConf struct {
 	AllowedOrigins string            `yaml:"allowedOrigins"`
 	JwtSecret      string            `yaml:"jwtSecret"`
 	Oidc           map[string]string `yaml:"oidc,omitempty"`
+}
+type ComponentsConf map[string]map[string]string
+
+type AiryConf struct {
+	Kubernetes KubernetesConf            `yaml:"kubernetes"`
+	Ingress    IngressConf               `yaml:"ingress"`
+	Security   SecurityConf              `yaml:"security"`
+	Components map[string]ComponentsConf `yaml:"components,omitempty"`
+}
+
+type HelmAiryConf struct {
+	Global AiryConf `yaml:"global"`
 }

--- a/cli/pkg/workspace/template/src/airy.yaml
+++ b/cli/pkg/workspace/template/src/airy.yaml
@@ -2,12 +2,12 @@ kubernetes:
   appImageTag: {{ .Version }}
   containerRegistry: ghcr.io/airyhq
   namespace: {{ .Namespace }}
-  ngrokEnabled: {{ default "false" .NgrokEnabled }}
+  ngrokEnabled: {{ default false .NgrokEnabled }}
 {{- if .Host }}
   host: {{ default "airy.core" .Host }}
 {{- end }}
 ingress:
-  https: {{ default "false" .Https}}
+  https: {{ default false .Https}}
   letsencryptEmail: {{ .LetsencryptEmail}}
   {{- if .LoadbalancerAnnotations }}
   loadbalancerAnnotations:
@@ -16,7 +16,7 @@ ingress:
   {{- end }}
   {{- end }}
 security:
-  allowedOrigins: "*"
+  allowedOrigins: '*'
   jwtSecret: {{ randAlphaNum 128 }}
 components:
   sources:

--- a/docs/docs/cli/usage.md
+++ b/docs/docs/cli/usage.md
@@ -140,6 +140,36 @@ airy ui [flags]
 
 ***
 
+## Upgrade
+
+Upgrades an instance of Airy Core
+
+#### Synopsis
+
+Upgrades an existing Airy Core instance, read from a workspace directory (default .)
+
+```
+airy upgrade [flags]
+```
+
+#### Options
+
+```
+      --approve          Upgrade automatically without asking for an approval (optional).
+  -h, --help             help for upgrade
+      --version string   Specify a version to upgrade to (optional).
+```
+
+#### Options inherited from parent commands
+
+```
+      --apihost string     Airy Core HTTP API endpoint
+      --workspace string   workspace directory of an Airy core instance (default is the cwd)
+```
+
+
+***
+
 ## Version
 
 Prints version information

--- a/docs/docs/getting-started/installation/aws.md
+++ b/docs/docs/getting-started/installation/aws.md
@@ -260,6 +260,16 @@ After setting these parameters, create your `Airy Core` instance with the follow
 airy create --provider aws --provider-config hostUpdate=false
 ```
 
+:::note
+In case you have created your Airy Core instance without Let's Encrypt and want to add it later, you must use the `airy upgrade` command.
+
+Even if you don't upgrade to a new version, just modify your `airy.yaml` file as explained in this section and run
+
+`airy upgrade`
+
+After the upgrade is done, continue with setting up your DNS and starting the ingress controller.
+:::
+
 #### Setup your DNS
 
 You should create a CNAME DNS record for the hostname that you set under `kubernetes.host` in the previous step to point to the hostname of the LoadBalancer, created by AWS for the ingress service:

--- a/docs/docs/getting-started/upgrade.md
+++ b/docs/docs/getting-started/upgrade.md
@@ -1,0 +1,73 @@
+---
+title: Upgrade your Airy Core instance
+sidebar_label: Upgrade
+---
+
+import TLDR from "@site/src/components/TLDR";
+
+<TLDR>
+
+Upgrade an existing installation of Airy Core.
+
+</TLDR>
+
+## Upgrade your CLI
+
+In order to upgrade your Airy Core instance, first you need to upgrade your Airy CLI, depending on your [installation method](/cli/introduction#step-2-install-the-airy-cli).
+
+You can check the current version of your Airy CLI with the `airy version` command:
+
+```
+airy version
+Version: 0.29.0, GitCommit: b47d7e46c884a45c4c2169f626ebd0ff9ff6ee8e
+```
+
+## Upgrade your Airy Core instance
+
+:::warning
+
+The upgrade of your Airy Core cluster will lead to downtime. Usually it takes seconds, but in case there is a migration or a reset of some of the streaming apps, this process might take longer, depending on the amount of data you have.
+
+For more information about specific upgrades, or if you have any questions, please join the [Airy Developers Community on Slack](https://airy-developers.slack.com/).
+
+:::
+
+Use the `airy upgrade` command to perform the upgrade of your Airy Core instance. Run `airy upgrade` to return information about your current Airy Core version and the latest version available. You will be prompted to proceed with the upgrade (omit this prompt by using the `--approve` flag).
+
+```sh
+$ airy upgrade
+CLI version:  0.29.0
+Current Airy Core version:  0.28.0
+New Airy Core version:  0.29.0
+
+Are you sure that you want to proceed? [Y/y]
+Y
+```
+
+:::note
+
+You need to be inside an Airy Core workspace directory to run the command.
+
+You can overwrite the path by specifying the `--workspace` flag, for example:
+
+`airy upgrade --workspace ~/.airy/production`.
+
+:::
+
+The upgrade will continue until complete. You will receive a notification to confirm that the upgrade was successful. The version will be updated inside the Kubernetes cluster and in your local `airy.yaml` file.
+
+```
+Upgrading the helm charts of Airy Core...
+Applying config from the configuration file.
+applied configuration for "security"
+Writing the new version into the configuration file.
+Copying the configuration file in the Airy Core K8s cluster.
+
+✅ Aity Core upgraded
+```
+
+## Troubleshooting
+
+The upgrade process will not delete any of the persistent data that is kept inside the Kafka cluster. If for any reason an upgrade fails, a rollback to your previous Airy Core version will be initiated.
+
+If you need further help, refer to our [Troubleshooting section](/getting-started/troubleshooting).

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -17,6 +17,7 @@ module.exports = {
           'Command Line Interface': ['cli/introduction', 'cli/usage'],
         },
         'getting-started/quickstart',
+        'getting-started/upgrade',
         'getting-started/troubleshooting',
         'getting-started/glossary',
       ],

--- a/infrastructure/helm-chart/charts/core/charts/provisioning/templates/job-wait.yaml
+++ b/infrastructure/helm-chart/charts/core/charts/provisioning/templates/job-wait.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: wait-for-api-communication
   annotations:
-    "helm.sh/hook": "post-install"
+    "helm.sh/hook": "post-install,post-upgrade"
 spec:
   template:
     spec:
@@ -29,7 +29,7 @@ kind: Job
 metadata:
   name: wait-for-frontend-ui
   annotations:
-    "helm.sh/hook": "post-install"
+    "helm.sh/hook": "post-install,post-upgrade"
 spec:
   template:
     spec:
@@ -55,7 +55,7 @@ kind: Job
 metadata:
   name: wait-for-frontend-chat-plugin
   annotations:
-    "helm.sh/hook": "post-install"
+    "helm.sh/hook": "post-install,post-upgrade"
 spec:
   template:
     spec:

--- a/infrastructure/helm-chart/charts/core/charts/upgrading/Chart.yaml
+++ b/infrastructure/helm-chart/charts/core/charts/upgrading/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Upgrading of Airy core
+name: upgrading
+version: 0-develop

--- a/infrastructure/helm-chart/charts/core/charts/upgrading/templates/scripts.yaml
+++ b/infrastructure/helm-chart/charts/core/charts/upgrading/templates/scripts.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: upgrading-scripts
+  namespace: {{ .Values.global.kubernetes.namespace }}
+data:
+  scale-down-deployment.sh: |
+    #!/bin/sh
+    deployment=${DEPLOYMENT_NAME}
+
+    kubectl scale deployment ${deployment} --replicas=0
+
+  scale-down-statefulset.sh: |
+    #!/bin/sh
+    statefulset=${STATEFULSET_NAME}
+
+    kubectl scale statefulset ${statefulset} --replicas=0
+
+  wait-for-empty-consumer-group.sh: |
+    #!/bin/sh
+    kafka_brokers=${KAFKA_BROKERS:-kafka:9092}
+    consumer_group=${CONSUMER_GROUP}
+    delay=${1:-5}
+
+    if kafka-consumer-groups.sh --bootstrap-server ${kafka_brokers} --list | grep -q ${consumer_group}
+    then
+      while ! kafka-consumer-groups.sh --bootstrap-server ${kafka_brokers} --group ${consumer_group} --describe 2>&1 | grep -q "has no active members"
+      do
+        echo "Waiting for the consumer group to be empty..."
+        sleep ${delay}
+      done
+    fi
+
+  reset-streaming-app.sh: |
+    #!/bin/sh
+    kafka_brokers=${KAFKA_BROKERS:-kafka:9092}
+    consumer_group=${CONSUMER_GROUP:-1}
+    input_topics=${INPUT_TOPICS}
+    offset=${OFFSET:-to-earliest}
+
+    kafka-streams-application-reset.sh --bootstrap-servers ${kafka_brokers} --${offset} --application-id ${consumer_group} --input-topics ${input_topics}

--- a/infrastructure/helm-chart/charts/core/charts/upgrading/templates/serviceaccount.yaml
+++ b/infrastructure/helm-chart/charts/core/charts/upgrading/templates/serviceaccount.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: airy-upgrade
+  namespace: {{ .Values.global.kubernetes.namespace }}
+automountServiceAccountToken: true
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: airy-upgrade
+  namespace: {{ .Values.global.kubernetes.namespace }}
+rules:
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "deployments/scale"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: airy-upgrade
+  namespace: {{ .Values.global.kubernetes.namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: airy-upgrade
+    namespace: {{ .Values.global.kubernetes.namespace }}
+roleRef:
+  kind: Role
+  name: airy-upgrade
+  apiGroup: rbac.authorization.k8s.io

--- a/infrastructure/helm-chart/charts/core/charts/upgrading/values.yaml
+++ b/infrastructure/helm-chart/charts/core/charts/upgrading/values.yaml
@@ -1,0 +1,2 @@
+kafkaImage: ghcr.io/airyhq/infrastructure/kafka
+kafkaImageTag: 2.7.0

--- a/infrastructure/lib/go/k8s/util/util.go
+++ b/infrastructure/lib/go/k8s/util/util.go
@@ -103,3 +103,20 @@ func ToObjectMeta(kubernetesObject interface{}) ObjectMeta {
 		ObjectMeta: field,
 	}
 }
+
+func ConfirmToProceed() bool {
+	var input string
+	fmt.Println("Are you sure that you want to proceed? [Y/y]")
+	_, err := fmt.Scanln(&input)
+	fmt.Println()
+	if err != nil {
+		return false
+	}
+	proceed := []string{"y", "Y"}
+	for _, v := range proceed {
+		if input == v {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The `airy upgrade` command currently produces the following output
```
$ airy upgrade
CLI version:  0.29.0-alpha
Current Airy Core version:  0.28.0
New Airy Core version:  0.29.0-alpha

Are you sure that you want to proceed? [Y/y]
y

Upgrading the helm charts of Airy Core...
Applying config from the configuration file.
applied configuration for "security"
Writing the new version into the configuration file.
Copying the configuration file in the Airy Core K8s cluster.

✅ Aity Core upgraded
```
- [x] Perform helm upgrade
- [x] Roll-back if the upgrade wasn't successful
- [x] Example definition of the migration jobs
- [x] Docs