### PR TITLE
Fixed broken link from Messages Send Section to Sources.

### DIFF
--- a/docs/docs/api/endpoints/messages-send.mdx
+++ b/docs/docs/api/endpoints/messages-send.mdx
@@ -2,7 +2,7 @@
 
 Sends a message to a conversation and returns a payload. Whatever is put on the
 `message` field will be forwarded "as-is" to the source's message endpoint. Therefore,
-the payload will look differently for each source. Refer to each [source's documentation](../../sources/introduction)
+the payload will look differently for each source. Refer to each [source's documentation](/sources/introduction)
 to see learn how to send text, media, and many more message types.
 
 

--- a/docs/docs/api/endpoints/messages-send.mdx
+++ b/docs/docs/api/endpoints/messages-send.mdx
@@ -2,7 +2,7 @@
 
 Sends a message to a conversation and returns a payload. Whatever is put on the
 `message` field will be forwarded "as-is" to the source's message endpoint. Therefore,
-the payload will look differently for each source. Refer to each [source's documentation](sources/introduction)
+the payload will look differently for each source. Refer to each [source's documentation](../../sources/introduction)
 to see learn how to send text, media, and many more message types.
 
 


### PR DESCRIPTION
The link is broken and is raised as issue in #2304 . This relative path fixes the location.
From https://airy.co/docs/core/api/endpoints/sources/introduction to https://airy.co/docs/core/sources/introduction

First time making changes.