### PR TITLE
[#2286] Core upgrade scripts for 0.29.0

### DIFF
--- a/cli/pkg/cmd/upgrade/upgrade.go
+++ b/cli/pkg/cmd/upgrade/upgrade.go
@@ -72,12 +72,7 @@ func upgrade(cmd *cobra.Command, args []string) {
 		console.Exit("Unable to copy config file into Airy Core :", cmErr)
 	}
 	if upgradeErr := helm.UpgradeCharts(); upgradeErr != nil {
-		fmt.Println("Upgrading the Helm Charts failed with err: ", upgradeErr)
-		fmt.Println("Attempting to roll back the upgrade...")
-		if rollBackErr := helm.RollBackUpgrade(oldVersion); rollBackErr != nil {
-			console.Exit("Roll Back of the upgrade failed with err: ", rollBackErr)
-		}
-		console.Exit("The roll back of the upgrade was successful.")
+		console.Exit("Upgrading the Helm Charts failed with err: ", upgradeErr)
 	}
 
 	fmt.Println("Applying config from the configuration file.")

--- a/docs/docs/getting-started/upgrade.md
+++ b/docs/docs/getting-started/upgrade.md
@@ -66,8 +66,27 @@ Copying the configuration file in the Airy Core K8s cluster.
 ✅ Aity Core upgraded
 ```
 
-## Troubleshooting
+## Cleanup the upgrade
 
-The upgrade process will not delete any of the persistent data that is kept inside the Kafka cluster. If for any reason an upgrade fails, a rollback to your previous Airy Core version will be initiated.
+The upgrade will create few additional resources (Kubernetes jobs and configMaps) which are not deleted automatically, so that there is a better insight of what happened during the upgrade.
+To cleanup those resources, run:
+
+```sh
+kubectl delete configmap -l core.airy.co/upgrade="true"
+kubectl delete job -l core.airy.co/upgrade="true"
+kubectl delete job -l core.airy.co/upgrade="post-upgrade"
+```
+
+## Rollback
+
+The upgrade process will not delete any of the persistent data that is kept inside the Kafka cluster. In case the upgrade fails, you can rollback to your previous Airy Core version. Clean-up the upgrade resources as instructed in the previous section and run:
+
+```sh
+helm rollback airy
+airy config apply
+kubectl delete pod -l app=airy-controller
+```
+
+## Troubleshooting
 
 If you need further help, refer to our [Troubleshooting section](/getting-started/troubleshooting).

--- a/infrastructure/helm-chart/charts/core/charts/provisioning/templates/job-wait.yaml
+++ b/infrastructure/helm-chart/charts/core/charts/provisioning/templates/job-wait.yaml
@@ -4,6 +4,8 @@ metadata:
   name: wait-for-api-communication
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     spec:
@@ -30,6 +32,8 @@ metadata:
   name: wait-for-frontend-ui
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     spec:
@@ -56,6 +60,8 @@ metadata:
   name: wait-for-frontend-chat-plugin
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     spec:

--- a/infrastructure/helm-chart/charts/core/charts/provisioning/templates/kafka-create-topics.yaml
+++ b/infrastructure/helm-chart/charts/core/charts/provisioning/templates/kafka-create-topics.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: kafka-create-topics
   annotations:
-    "helm.sh/hook": "pre-install"
+    "helm.sh/hook": "pre-install, pre-upgrade"
+    "helm.sh/hook-weight": "2"
 data:
   create-topics.sh: |
     #!/bin/bash

--- a/infrastructure/helm-chart/charts/core/charts/upgrading/templates/0.29.0.yaml
+++ b/infrastructure/helm-chart/charts/core/charts/upgrading/templates/0.29.0.yaml
@@ -105,12 +105,9 @@ spec:
       - name: check-webhook
         image: bitnami/kubectl
         command:  ['/bin/sh', '/opt/provisioning/check-existing-wehook.sh']
-        env:
-        - name: SYSTEM_TOKEN
-          valueFrom:
-            configMapKeyRef:
-              name: security
-              key: systemToken
+        envFrom:
+        - configMapRef:
+            name: security
         volumeMounts:
         - name: upgrade
           mountPath: /opt/provisioning
@@ -252,12 +249,9 @@ spec:
       - name: subscribe-webhook
         image: bitnami/kubectl
         command:  ['/bin/sh', '/opt/provisioning/subscribe-wehoook.sh']
-        env:
-        - name: SYSTEM_TOKEN
-          valueFrom:
-            configMapKeyRef:
-              name: security
-              key: systemToken
+        envFrom:
+        - configMapRef:
+            name: security
         volumeMounts:
         - name: upgrade
           mountPath: /opt/provisioning

--- a/infrastructure/helm-chart/charts/core/charts/upgrading/templates/0.29.0.yaml
+++ b/infrastructure/helm-chart/charts/core/charts/upgrading/templates/0.29.0.yaml
@@ -1,0 +1,283 @@
+{{ if eq .Values.global.kubernetes.appImageTag "0.29.0-alpha"}}
+# Helper scripts
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: upgrade-{{ .Values.global.kubernetes.appImageTag }}
+  namespace: {{ .Values.global.kubernetes.namespace }}
+  annotations:
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-weight": "1"
+  labels:
+    core.airy.co/upgrade: "true"
+data:
+  check-existing-wehook.sh: |
+    #!/bin/sh
+    system_token=${SYSTEM_TOKEN}
+    curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${system_token}" api-admin/webhooks.info -w "\n%{http_code}\n" > /tmp/response.txt
+    cat /tmp/response.txt
+    status_code=$(cat /tmp/response.txt | tail -n 1)
+    if [ "${status_code}" = "404" ]; then
+        kubectl patch configmap upgrade-{{ .Values.global.kubernetes.appImageTag }} --type merge -p '{"data":{"webhookUsed": "false"}}'
+    else
+      if [ "${status_code}" = "200" ]; then
+        webhooks=$(cat /tmp/response.txt | head -n 1)
+        if [ -z "${webhooks}" ]; then
+          kubectl patch configmap upgrade-{{ .Values.global.kubernetes.appImageTag }} --type merge -p '{"data":{"webhookUsed": "false"}}'
+        else
+          kubectl patch configmap upgrade-{{ .Values.global.kubernetes.appImageTag }} --type merge -p '{"data":{"webhookUsed": "true"}}'
+          echo ${webhooks} > /tmp/webhooks.yaml
+          kubectl delete configmap existing-webhooks
+          sleep 1
+          kubectl create configmap existing-webhooks --from-file=/tmp/webhooks.yaml
+          kubectl label configmap existing-webhooks core.airy.co/upgrade="true"
+        fi
+      fi
+    fi
+
+  subscribe-wehoook.sh: |
+    #!/bin/sh
+    system_token=${SYSTEM_TOKEN}
+    webhookUsed=$(kubectl get configmap upgrade-0.29.0-alpha -o jsonpath='{.data.webhookUsed}')
+    echo "Webhook used: ${webhookUsed}"
+    if [ "${webhookUsed}" = "true" ]; then
+      request=$(kubectl get configmap existing-webhooks -o jsonpath='{.data.webhooks\.yaml}')
+      curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${system_token}" -d "${request}" api-admin/webhooks.subscribe
+    fi
+---
+# Cleanup old jobs
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.global.kubernetes.appImageTag }}-cleanup-upgrade
+  namespace: {{ .Values.global.kubernetes.namespace }}
+  annotations:
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-weight": "0"
+  labels:
+    core.airy.co/upgrade: "true"
+spec:
+  ttlSecondsAfterFinished: 120
+  template:
+    spec:
+      containers:
+      - name: reset-app
+        image: "bitnami/kubectl"
+        command: ['/bin/sh', '/opt/provisioning/upgrade-cleanup.sh']
+        volumeMounts:
+        - name: upgrading-scripts
+          mountPath: /opt/provisioning
+      serviceAccountName: airy-upgrade
+      volumes:
+        - name: upgrading-scripts
+          configMap:
+            name: upgrading-scripts
+      restartPolicy: Never
+  backoffLimit: 3
+---
+# Migrate webhooks
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.global.kubernetes.appImageTag }}-upgrade-integration-webhooks
+  namespace: {{ .Values.global.kubernetes.namespace }}
+  annotations:
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-weight": "10"
+  labels:
+    core.airy.co/upgrade: "true"
+spec:
+  ttlSecondsAfterFinished: 120
+  template:
+    spec:
+      initContainers:
+      - name: wait-api-admin
+        image: busybox
+        command: ["/bin/sh", "/opt/provisioning/wait-for-service.sh"]
+        env:
+        - name: SERVICE_NAME
+          value: api-admin
+        - name: SERVICE_PORT
+          value: "80"
+        volumeMounts:
+        - name: provisioning-scripts
+          mountPath: /opt/provisioning
+      - name: check-webhook
+        image: bitnami/kubectl
+        command:  ['/bin/sh', '/opt/provisioning/check-existing-wehook.sh']
+        env:
+        - name: SYSTEM_TOKEN
+          valueFrom:
+            configMapKeyRef:
+              name: security
+              key: systemToken
+        volumeMounts:
+        - name: upgrade
+          mountPath: /opt/provisioning
+      - name: scale-down-consumer
+        image: bitnami/kubectl
+        command:  ['/bin/sh', '/opt/provisioning/scale-down-deployment.sh']
+        env:
+        - name: DEPLOYMENT_NAME
+          value: webhook-consumer
+        volumeMounts:
+        - name: upgrading-scripts
+          mountPath: /opt/provisioning
+      - name: scale-down-publisher
+        image: bitnami/kubectl
+        command:  ['/bin/sh', '/opt/provisioning/scale-down-deployment.sh']
+        env:
+        - name: DEPLOYMENT_NAME
+          value: webhook-publisher
+        volumeMounts:
+        - name: upgrading-scripts
+          mountPath: /opt/provisioning
+      - name: scale-down-beanstalkd
+        image: bitnami/kubectl
+        command:  ['/bin/sh', '/opt/provisioning/scale-down-statefulset.sh']
+        env:
+        - name: STATEFULSET_NAME
+          value: beanstalkd
+        volumeMounts:
+        - name: upgrading-scripts
+          mountPath: /opt/provisioning
+      - name: delete-pvc
+        image: bitnami/kubectl
+        command:  ['/bin/sh', '/opt/provisioning/delete-pvc.sh']
+        env:
+        - name: APP_LABEL
+          value: beanstalkd
+        volumeMounts:
+        - name: upgrading-scripts
+          mountPath: /opt/provisioning
+      - name: create-topics
+        image: "{{ .Values.kafkaImage }}:{{ .Values.kafkaImageTag }}"
+        command: ["/bin/sh", "/opt/provisioning/create-topics.sh"]
+        env:
+        - name: ZOOKEEPER
+          valueFrom:
+            configMapKeyRef:
+              name: kafka-config
+              key: ZOOKEEPER
+        - name: REPLICAS
+          valueFrom:
+            configMapKeyRef:
+              name: kafka-config
+              key: KAFKA_MINIMUM_REPLICAS
+        volumeMounts:
+        - name: kafka-create-topics
+          mountPath: /opt/provisioning
+      - name: wait-consumer-group
+        image: "{{ .Values.kafkaImage }}:{{ .Values.kafkaImageTag }}"
+        command:  ['/bin/sh', '/opt/provisioning/wait-for-empty-consumer-group.sh']
+        env:
+        - name: KAFKA_BROKERS
+          valueFrom:
+            configMapKeyRef:
+              name: kafka-config
+              key: KAFKA_BROKERS
+        - name: CONSUMER_GROUP
+          value: webhook.Publisher
+        volumeMounts:
+        - name: upgrading-scripts
+          mountPath: /opt/provisioning
+      containers:
+      - name: reset-app
+        image: "{{ .Values.kafkaImage }}:{{ .Values.kafkaImageTag }}"
+        command: ['/bin/sh', '/opt/provisioning/reset-streaming-app.sh']
+        env:
+        - name: KAFKA_BROKERS
+          valueFrom:
+            configMapKeyRef:
+              name: kafka-config
+              key: KAFKA_BROKERS
+        - name: INPUT_TOPICS
+          value: 'application.communication.messages,application.communication.metadata,application.communication.webhooks'
+        - name: CONSUMER_GROUP
+          value: webhook.Publisher
+        volumeMounts:
+        - name: upgrading-scripts
+          mountPath: /opt/provisioning
+      serviceAccountName: airy-upgrade
+      volumes:
+        - name: provisioning-scripts
+          configMap:
+            name: provisioning-scripts
+        - name: upgrading-scripts
+          configMap:
+            name: upgrading-scripts
+        - name: kafka-config
+          configMap:
+            name: kafka-config
+        - name: kafka-create-topics
+          configMap:
+            name: kafka-create-topics
+        - name: security
+          configMap:
+            name: security
+        - name: upgrade
+          configMap:
+            name: upgrade-{{ .Values.global.kubernetes.appImageTag }}
+      restartPolicy: Never
+  backoffLimit: 3
+---
+# Subscribe webhook
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.global.kubernetes.appImageTag }}-post-upgrade
+  namespace: {{ .Values.global.kubernetes.namespace }}
+  annotations:
+    "helm.sh/hook": "post-upgrade"
+    "helm.sh/hook-weight": "10"
+  labels:
+    core.airy.co/upgrade: "post-upgrade"
+spec:
+  ttlSecondsAfterFinished: 120
+  template:
+    spec:
+      initContainers:
+      - name: wait-api-admin
+        image: busybox
+        command: ["/bin/sh", "/opt/provisioning/wait-for-service.sh"]
+        env:
+        - name: SERVICE_NAME
+          value: api-admin
+        - name: SERVICE_PORT
+          value: "80"
+        volumeMounts:
+        - name: provisioning-scripts
+          mountPath: /opt/provisioning
+      containers:
+      - name: subscribe-webhook
+        image: bitnami/kubectl
+        command:  ['/bin/sh', '/opt/provisioning/subscribe-wehoook.sh']
+        env:
+        - name: SYSTEM_TOKEN
+          valueFrom:
+            configMapKeyRef:
+              name: security
+              key: systemToken
+        volumeMounts:
+        - name: upgrade
+          mountPath: /opt/provisioning
+      serviceAccountName: airy-upgrade
+      volumes:
+        - name: provisioning-scripts
+          configMap:
+            name: provisioning-scripts
+        - name: upgrading-scripts
+          configMap:
+            name: upgrading-scripts
+        - name: kafka-config
+          configMap:
+            name: kafka-config
+        - name: upgrade
+          configMap:
+            name: upgrade-{{ .Values.global.kubernetes.appImageTag }}
+        - name: security
+          configMap:
+            name: security
+      restartPolicy: Never
+  backoffLimit: 3
+{{ end }}

--- a/infrastructure/helm-chart/charts/core/charts/upgrading/templates/0.29.0.yaml
+++ b/infrastructure/helm-chart/charts/core/charts/upgrading/templates/0.29.0.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.global.kubernetes.appImageTag "0.29.0-alpha"}}
+{{ if eq .Values.global.kubernetes.appImageTag "0.29.0"}}
 # Helper scripts
 apiVersion: v1
 kind: ConfigMap
@@ -38,7 +38,7 @@ data:
   subscribe-wehoook.sh: |
     #!/bin/sh
     system_token=${SYSTEM_TOKEN}
-    webhookUsed=$(kubectl get configmap upgrade-0.29.0-alpha -o jsonpath='{.data.webhookUsed}')
+    webhookUsed=$(kubectl get configmap upgrade-{{ .Values.global.kubernetes.appImageTag }} -o jsonpath='{.data.webhookUsed}')
     echo "Webhook used: ${webhookUsed}"
     if [ "${webhookUsed}" = "true" ]; then
       request=$(kubectl get configmap existing-webhooks -o jsonpath='{.data.webhooks\.yaml}')

--- a/infrastructure/helm-chart/charts/core/charts/upgrading/templates/scripts.yaml
+++ b/infrastructure/helm-chart/charts/core/charts/upgrading/templates/scripts.yaml
@@ -3,6 +3,9 @@ kind: ConfigMap
 metadata:
   name: upgrading-scripts
   namespace: {{ .Values.global.kubernetes.namespace }}
+  annotations:
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-weight": "-5"
 data:
   scale-down-deployment.sh: |
     #!/bin/sh
@@ -16,11 +19,16 @@ data:
 
     kubectl scale statefulset ${statefulset} --replicas=0
 
+  delete-pvc.sh: |
+    #!/bin/sh
+    app_label=${APP_LABEL}
+    kubectl delete pvc -l app=${app_label}
+
   wait-for-empty-consumer-group.sh: |
     #!/bin/sh
     kafka_brokers=${KAFKA_BROKERS:-kafka:9092}
     consumer_group=${CONSUMER_GROUP}
-    delay=${1:-5}
+    delay=${DELAY:-5}
 
     if kafka-consumer-groups.sh --bootstrap-server ${kafka_brokers} --list | grep -q ${consumer_group}
     then
@@ -34,8 +42,29 @@ data:
   reset-streaming-app.sh: |
     #!/bin/sh
     kafka_brokers=${KAFKA_BROKERS:-kafka:9092}
-    consumer_group=${CONSUMER_GROUP:-1}
+    consumer_group=${CONSUMER_GROUP}
     input_topics=${INPUT_TOPICS}
     offset=${OFFSET:-to-earliest}
 
     kafka-streams-application-reset.sh --bootstrap-servers ${kafka_brokers} --${offset} --application-id ${consumer_group} --input-topics ${input_topics}
+
+  wait-for-lag.sh: |
+    #!/bin/sh
+    kafka_brokers=${KAFKA_BROKERS:-kafka:9092}
+    consumer_group=${CONSUMER_GROUP}
+    max_consumer_lag=${MAX_CONSUMER_LAG:-5}
+    delay=${DELAY:-10}
+
+    consumer_lag=$(kafka-consumer-groups.sh --bootstrap-server ${kafka_brokers} --group ${consumer_group} --describe | awk '{ print $6; }' | grep -v "-" | awk '{s+=$1} END {print s}')
+    while [ ${consumer_lag} -gt ${max_consumer_lag} ] ; do 
+      echo "Current consumer lag for group ${consumer_group} is ${consumer_lag}. Waiting to reach ${max_consumer_lag}..."
+      sleep ${delay}
+      consumer_lag=$(kafka-consumer-groups.sh --bootstrap-server ${kafka_brokers} --group ${consumer_group} --describe | awk '{ print $6; }' | grep -v "-" | awk '{s+=$1} END {print s}')
+    done
+
+  upgrade-cleanup.sh: |
+    #!/bin/sh
+    kubectl delete configmap -l core.airy.co/upgrade="true"
+    kubectl delete job -l core.airy.co/upgrade="true"
+    kubectl delete job -l core.airy.co/upgrade="post-upgrade"
+    kubectl delete job -l job-name

--- a/infrastructure/helm-chart/charts/core/charts/upgrading/templates/serviceaccount.yaml
+++ b/infrastructure/helm-chart/charts/core/charts/upgrading/templates/serviceaccount.yaml
@@ -3,6 +3,9 @@ kind: ServiceAccount
 metadata:
   name: airy-upgrade
   namespace: {{ .Values.global.kubernetes.namespace }}
+  annotations:
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-weight": "-10"
 automountServiceAccountToken: true
 ---
 kind: Role
@@ -10,16 +13,28 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: airy-upgrade
   namespace: {{ .Values.global.kubernetes.namespace }}
+  annotations:
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-weight": "-10"
 rules:
 - apiGroups: ["extensions", "apps"]
-  resources: ["deployments", "deployments/scale"]
+  resources: ["deployments", "deployments/scale", "statefulsets", "statefulsets/scale"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["configmaps", "persistentvolumeclaims", "persistentvolumes", "persistentvolumeclaims/status", "secrets"]
+  verbs: ["create","delete","get","list","patch","update","watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["jobs"]
+  verbs: ["create","delete","get","list","patch","update","watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: airy-upgrade
   namespace: {{ .Values.global.kubernetes.namespace }}
+  annotations:
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-weight": "-10"
 subjects:
   - kind: ServiceAccount
     name: airy-upgrade

--- a/infrastructure/tools/topics/src/main/java/co/airy/tools/topics/Application.java
+++ b/infrastructure/tools/topics/src/main/java/co/airy/tools/topics/Application.java
@@ -23,7 +23,9 @@ public class Application {
                 "\n" +
                 "  annotations:" +
                 "\n" +
-                "    \"helm.sh/hook\": \"pre-install\"" +
+                "    \"helm.sh/hook\": \"pre-install, pre-upgrade\"" +
+                "\n" +
+                "    \"helm.sh/hook-weight\": \"2\"" +
                 "\n" +
                 "data:" +
                 "\n" +


### PR DESCRIPTION
The migration jobs are consisted of few containers which run in sequence until completion:

```
0.29.0-alpha-post-upgrade-txnnk                   0/1     Init:0/2   0          9m8s
0.29.0-alpha-upgrade-integration-webhooks-vdsl2   0/1     Init:2/8    0          13s
```
The procedure is the following. There is one `pre-upgrade` job and one `post-upgrade` job.

**Pre-upgrade**
1. Wait until api-admin is available
2. Get the existing webhooks and write them to a temporary configMap
3. Scale down webhook-consumer
4. Scale down webhook-publisher
5. Scale down beanstalkd
6. Delete the beanstalkd PVC
7. Re-create all the topics
8. Wait for the webhook.Publisher consumerGroup to be empty
9. Reset the webhook.Publisher consumerGroup

**Upgrade**
1. Upgrade the tag/helm-chart
2. Apply the configuration (by now everything should be running with the new version)

**Post-upgrade:**
1. Wait until api-admin is available
2. Subscribe the old webhooks
3. Cleanup (we do this manually for now, because it deletes all the jobs and logs)

