### PR TITLE
[#2406] Instagram Source: Render Messages with Media & Share in Inbox UI

### DIFF
--- a/lib/typescript/render/components/ImageWithFallback/index.tsx
+++ b/lib/typescript/render/components/ImageWithFallback/index.tsx
@@ -27,11 +27,13 @@ export const ImageWithFallback = ({src, alt, className}: ImageRenderProps) => {
   };
 
   return (
-    <img
-      className={className}
-      src={imageFailed ? 'https://s3.amazonaws.com/assets.airy.co/fallbackMediaImage.svg' : src}
-      alt={imageFailed ? 'The image failed to load' : alt}
-      onError={() => loadingFailed()}
-    />
+    <a href={src} target="_blank" rel="noopener noreferrer">
+      <img
+        className={className}
+        src={imageFailed ? 'https://s3.amazonaws.com/assets.airy.co/fallbackMediaImage.svg' : src}
+        alt={imageFailed ? 'The image failed to load' : alt}
+        onError={() => loadingFailed()}
+      />
+    </a>
   );
 };

--- a/lib/typescript/render/components/Text/index.module.scss
+++ b/lib/typescript/render/components/Text/index.module.scss
@@ -10,7 +10,7 @@
   padding: 10px;
   margin-top: 5px;
   border-radius: 8px;
-  font-family: 'Lato', sans-serif;
+  @include font-base;
 }
 
 .contactContent {

--- a/lib/typescript/render/components/Video/index.tsx
+++ b/lib/typescript/render/components/Video/index.tsx
@@ -31,10 +31,12 @@ export const Video = ({videoUrl}: VideoRenderProps) => {
         {isVideoFailed ? (
           <div>Loading of video failed</div>
         ) : (
-          <video className={styles.video} controls preload="metadata" onError={loadingFailed}>
-            <source src={videoUrl} type="video/mp4" />
-            Your browser does not support the video tag.
-          </video>
+          <a href={videoUrl} target="_blank" rel="noopener noreferrer">
+            <video className={styles.video} controls preload="metadata" onError={loadingFailed}>
+              <source src={videoUrl} type="video/mp4" />
+              Your browser does not support the video tag.
+            </video>
+          </a>
         )}
       </div>
     </div>

--- a/lib/typescript/render/providers/chatplugin/ChatPluginRender.tsx
+++ b/lib/typescript/render/providers/chatplugin/ChatPluginRender.tsx
@@ -131,7 +131,7 @@ function mapContent(message): ContentUnion {
 
   return {
     type: 'text',
-    text: 'Unknown message type',
+    text: 'Unsupported message type',
   };
 }
 
@@ -152,7 +152,7 @@ const parseAttachment = (attachment: SimpleAttachment): AttachmentUnion => {
 
   return {
     type: 'text',
-    text: 'Unknown message type',
+    text: 'Unsupported message type',
   };
 };
 

--- a/lib/typescript/render/providers/facebook/FacebookRender.tsx
+++ b/lib/typescript/render/providers/facebook/FacebookRender.tsx
@@ -16,6 +16,7 @@ import {MediaTemplate} from './components/MediaTemplate';
 import {FallbackAttachment} from './components/FallbackAttachment';
 import {StoryMention} from './components/InstagramStoryMention';
 import {StoryReplies} from './components/InstagramStoryReplies';
+import {Share} from './components/InstagramShare';
 
 export const FacebookRender = (props: RenderPropsUnion) => {
   const message = props.message;
@@ -84,6 +85,9 @@ function render(content: ContentUnion, props: RenderPropsUnion) {
         />
       );
 
+    case 'share':
+      return <Share url={content.url} fromContact={props.message.fromContact || false} />;
+
     default:
       return null;
   }
@@ -142,6 +146,13 @@ const parseAttachment = (
     return {
       type: 'video',
       videoUrl: attachment.payload.url,
+    };
+  }
+
+  if (attachment.type === 'share') {
+    return {
+      type: 'share',
+      url: attachment.payload.url,
     };
   }
 

--- a/lib/typescript/render/providers/facebook/FacebookRender.tsx
+++ b/lib/typescript/render/providers/facebook/FacebookRender.tsx
@@ -166,7 +166,7 @@ const parseAttachment = (
 
   return {
     type: 'text',
-    text: 'Unknown message type',
+    text: 'Unsupported message type',
   };
 };
 
@@ -227,7 +227,7 @@ function facebookInbound(message): ContentUnion {
 
   return {
     type: 'text',
-    text: 'Unkown message type',
+    text: 'Unsupported message type',
   };
 }
 
@@ -299,6 +299,6 @@ function facebookOutbound(message): ContentUnion {
 
   return {
     type: 'text',
-    text: 'Unknown message type',
+    text: 'Unsupported message type',
   };
 }

--- a/lib/typescript/render/providers/facebook/components/InstagramShare/index.module.scss
+++ b/lib/typescript/render/providers/facebook/components/InstagramShare/index.module.scss
@@ -13,23 +13,6 @@
   @include font-base;
 }
 
-.activeStory {
-  display: flex;
-  align-items: center;
-}
-
-.activeStoryLink:link,
-.activeStoryLink:hover,
-.activeStoryLink:visited,
-.activeStoryLink:active {
-  color: var(--color-text-contrast);
-  font-style: italic;
-}
-
-.expiredStory {
-  font-style: italic;
-}
-
 .contactContent {
   @extend .textMessage;
   background: var(--color-background-blue);
@@ -40,4 +23,26 @@
   @extend .textMessage;
   background: var(--color-airy-blue);
   color: white;
+}
+
+.container {
+  display: flex;
+  align-items: center;
+}
+
+.container svg {
+  width: 15px;
+  height: auto;
+  margin-left: 4px;
+  path {
+    fill: var(--color-text-contrast);
+  }
+}
+
+.shareLink:link,
+.shareLink:hover,
+.shareLink:visited,
+.shareLink:active {
+  color: var(--color-text-contrast);
+  font-style: italic;
 }

--- a/lib/typescript/render/providers/facebook/components/InstagramShare/index.tsx
+++ b/lib/typescript/render/providers/facebook/components/InstagramShare/index.tsx
@@ -1,0 +1,16 @@
+import React, {useState} from 'react';
+import {ReactComponent as RightArrowIcon} from 'assets/images/icons/rightArrow.svg';
+import styles from './index.module.scss';
+
+export const Share = ({url, fromContact}) => {
+  return (
+    <div className={`${fromContact ? styles.contactContent : styles.memberContent}`}>
+      <div className={styles.container}>
+        <a className={styles.shareLink} href={url} target="_blank" rel="noopener noreferrer">
+          Shared Post
+        </a>
+        <RightArrowIcon />
+      </div>
+    </div>
+  );
+};

--- a/lib/typescript/render/providers/facebook/components/InstagramShare/index.tsx
+++ b/lib/typescript/render/providers/facebook/components/InstagramShare/index.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {ReactComponent as RightArrowIcon} from 'assets/images/icons/rightArrow.svg';
 import styles from './index.module.scss';
 

--- a/lib/typescript/render/providers/facebook/components/InstagramStoryReplies/index.module.scss
+++ b/lib/typescript/render/providers/facebook/components/InstagramStoryReplies/index.module.scss
@@ -10,7 +10,7 @@
   padding: 10px;
   margin-top: 5px;
   border-radius: 8px;
-  font-family: 'Lato', sans-serif;
+  @include font-base;
 }
 
 .contactContent {

--- a/lib/typescript/render/providers/facebook/facebookModel.ts
+++ b/lib/typescript/render/providers/facebook/facebookModel.ts
@@ -4,7 +4,7 @@ export interface Attachment {
   url?: string | null;
 }
 export interface SimpleAttachment {
-  type: 'image' | 'video' | 'audio' | 'file' | 'fallback';
+  type: 'image' | 'video' | 'audio' | 'file' | 'share' | 'fallback';
   title?: string;
   url?: string;
   payload?: {title?: string; url?: string} | null;
@@ -158,6 +158,7 @@ export interface Fallback extends Content {
   url: string;
 }
 
+//Instagram-specific
 export interface StoryMentionContent extends Content {
   type: 'story_mention';
   url: string;
@@ -168,6 +169,11 @@ export interface StoryRepliesContent extends Content {
   type: 'story_replies';
   url: string;
   sentAt: Date;
+}
+
+export interface ShareContent extends Content {
+  type: 'share';
+  url: string;
 }
 
 // Add a new facebook content model here:
@@ -185,6 +191,7 @@ export type ContentUnion =
   | MediaTemplate
   | StoryMentionContent
   | StoryRepliesContent
+  | ShareContent
   | Fallback;
 
 export type AttachmentUnion =
@@ -197,4 +204,5 @@ export type AttachmentUnion =
   | GenericTemplate
   | MediaTemplate
   | StoryMentionContent
+  | ShareContent
   | Fallback;

--- a/lib/typescript/render/providers/google/GoogleRender.tsx
+++ b/lib/typescript/render/providers/google/GoogleRender.tsx
@@ -130,7 +130,7 @@ function googleInbound(message): ContentUnion {
 
   return {
     type: 'text',
-    text: 'Unkown message type',
+    text: 'Unsupported message type',
   };
 }
 
@@ -216,6 +216,6 @@ function googleOutbound(message): ContentUnion {
 
   return {
     type: 'text',
-    text: 'Unknown message type',
+    text: 'Unsupported message type',
   };
 }


### PR DESCRIPTION
closes #2406 (follow up to #2109)

**changes:** 
- shares 
- attachments (audio/video/image/files) (same as Facebook's)
- changed `unknown message type` to `unsupported message type `for all known sources 

<img width="288" alt="Screenshot 2021-09-20 at 13 20 00" src="https://user-images.githubusercontent.com/38159391/133994237-d902f7ff-0abc-4bb1-b415-0abbc70d755c.png">


<img width="481" alt="Screenshot 2021-09-20 at 13 19 10" src="https://user-images.githubusercontent.com/38159391/133994718-f0926aff-6912-4eed-988a-e683a68c9af7.png">


