### PR TITLE
[#2405] Icons for Rendering/Sending File Attachments

### DIFF
--- a/lib/typescript/render/SourceMessagePreview.tsx
+++ b/lib/typescript/render/SourceMessagePreview.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {ReactComponent as AttachmentTemplate} from 'assets/images/icons/attachmentTemplate.svg';
 import {ReactComponent as AttachmentImage} from 'assets/images/icons/attachmentImage.svg';
 import {ReactComponent as AttachmentVideo} from 'assets/images/icons/attachmentVideo.svg';
+import {ReactComponent as AttachmentAudio} from 'assets/images/icons/file-audio.svg';
+import {ReactComponent as AttachmentFile} from 'assets/images/icons/file-download.svg';
 import {ReactComponent as RichCardIcon} from 'assets/images/icons/richCardIcon.svg';
 import {Conversation, Message} from 'model';
 interface SourceMessagePreviewProps {
@@ -73,16 +75,33 @@ export const SourceMessagePreview = (props: SourceMessagePreviewProps) => {
         isImageFromGoogleSource(lastMessageContent.message?.text)
       ) {
         return <AttachmentImage />;
-      } else if (lastMessageContent.message?.attachments?.[0].type === 'video') {
+      }
+
+      if (lastMessageContent.message?.attachments?.[0].type === 'video') {
         return <AttachmentVideo style={{height: '24px', width: '24px', margin: '0px'}} />;
-      } else if (lastMessageContent.suggestionResponse) {
+      }
+
+      if (lastMessageContent.message?.attachments?.[0].type === 'audio') {
+        return <AttachmentAudio style={{height: '24px', width: '24px', margin: '0px'}} />;
+      }
+
+      if (lastMessageContent.message?.attachments?.[0].type === 'file') {
+        return <AttachmentFile style={{height: '24px', width: '24px', margin: '0px'}} />;
+      }
+
+      if (lastMessageContent.suggestionResponse) {
         return <>{conversation.lastMessage.content.suggestionResponse.text}</>;
-      } else if (lastMessageContent.image) {
+      }
+
+      if (lastMessageContent.image) {
         return <AttachmentImage />;
-      } else if (lastMessageContent.richCard) {
+      }
+
+      if (lastMessageContent.richCard) {
         return <RichCardIcon style={{height: '24px', width: '24px', margin: '0px'}} />;
       }
     }
+
     return <AttachmentTemplate />;
   };
 


### PR DESCRIPTION
closes #2405 
<img width="318" alt="Screenshot 2021-09-20 at 14 01 20" src="https://user-images.githubusercontent.com/38159391/133998934-e486fab2-4889-4ba3-aa9e-8cf9c3707ce3.png">
<img width="321" alt="Screenshot 2021-09-20 at 14 01 48" src="https://user-images.githubusercontent.com/38159391/133998939-1454e695-1e6b-43ff-87ee-57b92bfe70a1.png">

