### PR TITLE
[#2445] fix http client library compatibility with node.js

### DIFF
--- a/lib/typescript/httpclient/BUILD
+++ b/lib/typescript/httpclient/BUILD
@@ -18,7 +18,6 @@ ts_web_library(
         "@npm//camelcase-keys",
         "@npm//node-fetch",
         "@npm//regenerator-runtime",
-        "@npm//core-js",
     ],
 )
 
@@ -31,7 +30,6 @@ web_library(
         "camelcase-keys": "camelcase-keys",
         "node-fetch": "node-fetch",
         "regenerator-runtime": "regenerator-runtime",
-        "core-js": "core-js",
     },
     module_deps = module_deps,
     output = {

--- a/lib/typescript/httpclient/client.ts
+++ b/lib/typescript/httpclient/client.ts
@@ -54,7 +54,6 @@ import {
 import fetch from 'node-fetch';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import regeneratorRuntime from 'regenerator-runtime';
-import 'core-js';
 
 function isString(object: any) {
   return typeof object === 'string' || object instanceof String;

--- a/lib/typescript/httpclient/package.json
+++ b/lib/typescript/httpclient/package.json
@@ -18,7 +18,6 @@
     "@types/node": "^14.14.37",
     "camelcase-keys": "^6.2.2",
     "node-fetch": "^2.0.0", 
-    "regenerator-runtime": "^0.13.9",
-    "core-js": "3.18.1"
+    "regenerator-runtime": "^0.13.9"
   }
 }


### PR DESCRIPTION
closes #2445 

**Changes** 
- added necessary packages used in the library 
- [ Regenerator](https://github.com/facebook/regenerator) added because using the library in Node.js produced the [error
`ReferenceError: regeneratorRuntime is not defined`](https://github.com/babel/babel/issues/9849)