### PR TITLE
[#2503] Specify resources for components

### DIFF
--- a/infrastructure/helm-chart/charts/components/charts/api/charts/api-communication/templates/communication/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/api/charts/api-communication/templates/communication/deployment.yaml
@@ -56,6 +56,8 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 3
+        resources:
+{{ toYaml .Values.communication.resources | indent 10 }}
       initContainers:
       - name: wait
         image: busybox

--- a/infrastructure/helm-chart/charts/components/charts/api/charts/api-communication/templates/websocket/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/api/charts/api-communication/templates/websocket/deployment.yaml
@@ -56,6 +56,8 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 3
+        resources:
+{{ toYaml .Values.websocket.resources | indent 10 }}
       initContainers:
       - name: wait
         image: busybox

--- a/infrastructure/helm-chart/charts/components/charts/api/charts/api-communication/values.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/api/charts/api-communication/values.yaml
@@ -3,5 +3,19 @@ mandatory: false
 enabled: true
 communication:
   image: api/communication
+  resources:
+    requests:
+      cpu: "100m"  
+      memory: "128Mi"
+    limits:
+      cpu: "2000m"
+      memory: "2048Mi"
 websocket:
   image: api/websocket
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1024Mi"

--- a/infrastructure/helm-chart/charts/components/charts/frontend/charts/frontend-ui/templates/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/frontend/charts/frontend-ui/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 10
           failureThreshold: 3
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
       volumes:
         - name: provisioning-scripts
           configMap:

--- a/infrastructure/helm-chart/charts/components/charts/frontend/charts/frontend-ui/values.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/frontend/charts/frontend-ui/values.yaml
@@ -2,3 +2,10 @@ component: frontend-ui
 mandatory: false
 enabled: true
 image: frontend/ui
+resources:
+  requests:
+    cpu: "50m"  
+    memory: "64Mi"
+  limits:
+    cpu: "500m"
+    memory: "512Mi"

--- a/infrastructure/helm-chart/charts/components/charts/integration/charts/source-api/Chart.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/integration/charts/source-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for the Sources Chatplugin app
-name: integration-source-api
+name: source-api
 version: 0-develop

--- a/infrastructure/helm-chart/charts/components/charts/integration/charts/source-api/templates/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/integration/charts/source-api/templates/deployment.yaml
@@ -65,6 +65,8 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 3
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
       initContainers:
       - name: wait
         image: busybox

--- a/infrastructure/helm-chart/charts/components/charts/integration/charts/source-api/values.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/integration/charts/source-api/values.yaml
@@ -1,3 +1,10 @@
 component: integration-source-api
 mandatory: false
 image: sources/api
+resources:
+  requests:
+    cpu: "50m"
+    memory: "128Mi"
+  limits:
+    cpu: "1000m"
+    memory: "1024Mi"

--- a/infrastructure/helm-chart/charts/components/charts/integration/charts/webhook/Chart.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/integration/charts/webhook/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for the Webhook integration component
-name: integration-webhook
+name: webhook
 version: 0-develop

--- a/infrastructure/helm-chart/charts/components/charts/integration/charts/webhook/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/integration/charts/webhook/templates/deployments.yaml
@@ -66,6 +66,8 @@ spec:
               - name: Health-Check
                 value: health-check
           initialDelaySeconds: 60
+        resources:
+{{ toYaml .Values.consumer.resources | indent 10 }}
       initContainers:
       - name: wait
         image: busybox
@@ -160,6 +162,8 @@ spec:
               - name: Health-Check
                 value: health-check
           initialDelaySeconds: 60
+        resources:
+{{ toYaml .Values.publisher.resources | indent 10 }}
       initContainers:
       - name: wait
         image: busybox

--- a/infrastructure/helm-chart/charts/components/charts/integration/charts/webhook/values.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/integration/charts/webhook/values.yaml
@@ -3,5 +3,19 @@ mandatory: false
 enabled: true
 consumer:
   image: webhook/consumer
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1024Mi"
 publisher:
   image: webhook/publisher
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "1000m"
+      memory: "2048Mi"

--- a/infrastructure/helm-chart/charts/components/charts/media/charts/resolver/Chart.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/media/charts/resolver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for the Media Resolver app
-name: media-resolver
+name: resolver
 version: 0-develop

--- a/infrastructure/helm-chart/charts/components/charts/media/charts/resolver/templates/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/media/charts/resolver/templates/deployment.yaml
@@ -58,9 +58,12 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 10
             failureThreshold: 3
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
       initContainers:
       - name: wait
         image: busybox
+        imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:
         - name: KAFKA_BROKERS

--- a/infrastructure/helm-chart/charts/components/charts/media/charts/resolver/values.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/media/charts/resolver/values.yaml
@@ -2,3 +2,10 @@ component: media-resolver
 mandatory: false
 enabled: true
 image: media/resolver
+resources:
+  requests:
+    cpu: "50m"
+    memory: "128Mi"
+  limits:
+    cpu: "1000m"
+    memory: "1024Mi"

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/templates/backend/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/templates/backend/deployment.yaml
@@ -66,6 +66,8 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 3
+        resources:
+{{ toYaml .Values.backend.resources | indent 10 }}
       initContainers:
       - name: wait
         image: busybox

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/templates/frontend/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/templates/frontend/deployment.yaml
@@ -43,6 +43,8 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 10
           failureThreshold: 3
+        resources:
+{{ toYaml .Values.frontend.resources | indent 10 }}
       initContainers:
       - name: wait
         image: busybox

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/values.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/values.yaml
@@ -3,5 +3,19 @@ mandatory: false
 enabled: true
 backend:
   image: sources/chat-plugin
+  resources:
+    requests:
+      cpu: "50m"  
+      memory: "128Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1024Mi"
 frontend:
   image: frontend/chat-plugin
+  resources:
+    requests:
+      cpu: "50m"  
+      memory: "64Mi"
+    limits:
+      cpu: "500m"
+      memory: "1024Mi"

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/facebook/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/facebook/templates/deployments.yaml
@@ -71,6 +71,8 @@ spec:
               - name: Health-Check
                 value: health-check
             initialDelaySeconds: 60
+          resources:
+{{ toYaml .Values.connector.resources | indent 12 }}
       initContainers:
       - name: wait
         image: busybox
@@ -153,6 +155,8 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 3
+        resources:
+{{ toYaml .Values.eventsRouter.resources | indent 10 }}
       initContainers:
       - name: wait
         image: busybox

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/facebook/values.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/facebook/values.yaml
@@ -3,5 +3,19 @@ mandatory: false
 enabled: true
 connector:
   image: sources/facebook-connector
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1024Mi"
 eventsRouter:
   image: sources/facebook-events-router
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1024Mi"

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/google/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/google/templates/deployments.yaml
@@ -66,6 +66,8 @@ spec:
               - name: Health-Check
                 value: health-check
             initialDelaySeconds: 60
+          resources:
+{{ toYaml .Values.connector.resources | indent 12 }}
       initContainers:
       - name: wait
         image: busybox
@@ -151,6 +153,8 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 3
+        resources:
+{{ toYaml .Values.eventsRouter.resources | indent 10 }}
       initContainers:
       - name: wait
         image: busybox

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/google/values.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/google/values.yaml
@@ -3,5 +3,19 @@ mandatory: false
 enabled: true
 connector:
   image: sources/google-connector
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1024Mi"
 eventsRouter:
   image: sources/google-events-router
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1024Mi"

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/twilio/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/twilio/templates/deployments.yaml
@@ -66,6 +66,8 @@ spec:
               - name: Health-Check
                 value: health-check
             initialDelaySeconds: 60
+          resources:
+{{ toYaml .Values.connector.resources | indent 12 }}
       initContainers:
       - name: wait
         image: busybox
@@ -153,6 +155,8 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 3
+        resources:
+{{ toYaml .Values.eventsRouter.resources | indent 10 }}
       initContainers:
       - name: wait
         image: busybox

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/twilio/values.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/twilio/values.yaml
@@ -3,5 +3,19 @@ mandatory: false
 enabled: true
 connector:
   image: sources/twilio-connector
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1024Mi"
 eventsRouter:
   image: sources/twilio-events-router
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1024Mi"

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/viber/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/viber/templates/deployments.yaml
@@ -61,6 +61,8 @@ spec:
                 - name: Health-Check
                   value: health-check
             initialDelaySeconds: 60
+          resources:
+{{ toYaml .Values.connector.resources | indent 12 }}
       initContainers:
         - name: wait
           image: busybox
@@ -148,6 +150,8 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 10
             failureThreshold: 3
+          resources:
+{{ toYaml .Values.eventsRouter.resources | indent 12 }}
       initContainers:
         - name: wait
           image: busybox

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/viber/values.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/viber/values.yaml
@@ -3,5 +3,19 @@ mandatory: false
 enabled: true
 connector:
   image: sources/viber-connector
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1024Mi"
 eventsRouter:
   image: sources/viber-events-router
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1024Mi"

--- a/infrastructure/helm-chart/charts/components/templates/api/admin/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/templates/api/admin/deployment.yaml
@@ -72,6 +72,8 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 3
+        resources:
+{{ toYaml .Values.api.admin.resources | indent 10 }}
       initContainers:
       - name: wait
         image: busybox

--- a/infrastructure/helm-chart/charts/components/values.yaml
+++ b/infrastructure/helm-chart/charts/components/values.yaml
@@ -4,3 +4,10 @@ api:
     image: api/admin
     mandatory: true
     enabled: true
+    resources:
+      requests:
+        cpu: "100m"  
+        memory: "128Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1024Mi"

--- a/infrastructure/helm-chart/charts/prerequisites/charts/beanstalkd/templates/statefulset.yaml
+++ b/infrastructure/helm-chart/charts/prerequisites/charts/beanstalkd/templates/statefulset.yaml
@@ -23,8 +23,11 @@ spec:
         image: "{{ .Values.prometheusExporterImage }}:{{ .Values.prometheusExporterImageTag }}"
         resources:
           requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
             cpu: 100m
-            memory: 100Mi
+            memory: 256Mi
         ports:
         - containerPort: {{ .Values.prometheusExporterPort }}
           name: exporter

--- a/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/kafka/templates/prometheus.yaml
+++ b/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/kafka/templates/prometheus.yaml
@@ -32,8 +32,8 @@ spec:
           - "--kafka.server={{ template "kafka.name" . }}:{{  .Values.port }}"
           resources:
             requests:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 50m
+              memory: 64Mi
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
           ports:
             - containerPort: {{ .Values.prometheus.exporterPort }}

--- a/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/kafka/values.yaml
+++ b/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/kafka/values.yaml
@@ -17,7 +17,13 @@ persistence:
   size: 10Gi
   disksPerBroker: 1
 heapOptions: "-Xms512M -Xmx512M"
-resources: {}
+resources:
+  requests:
+    cpu: "300m"  
+    memory: "512Mi"
+  limits:
+    cpu: "2000m"
+    memory: "4096Mi"
 podAnnotations: {}
 nodeSelector: {}
 tolerations: []

--- a/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/schema-registry/values.yaml
+++ b/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/schema-registry/values.yaml
@@ -7,3 +7,10 @@ servicePort: 8081
 kafka:
   bootstrapServers: kafka-headless:9092
   minBrokers: 1
+resources:
+  requests:
+    cpu: "50m"  
+    memory: "64Mi"
+  limits:
+    cpu: "1000m"
+    memory: "1024Mi"

--- a/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/zookeeper/values.yaml
+++ b/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/zookeeper/values.yaml
@@ -19,7 +19,13 @@ persistence:
   enabled: true
   dataDirSize: 5Gi
   dataLogDirSize: 5Gi
-resources: {}  
+resources:
+  requests:
+    cpu: "100m"  
+    memory: "128Mi"
+  limits:
+    cpu: "1000m"
+    memory: "2048Mi"
 podAnnotations: {}
 nodeSelector: {}
 tolerations: []

--- a/infrastructure/helm-chart/defaultResourceLimites.yaml
+++ b/infrastructure/helm-chart/defaultResourceLimites.yaml
@@ -1,0 +1,175 @@
+prerequisites:
+  kafka:
+    kafka:
+      resources:
+        requests:
+          cpu: "300m"  
+          memory: "512Mi"
+        limits:
+          cpu: "2000m"
+          memory: "4096Mi"
+    zookeeper:
+      resources:
+        requests:
+          cpu: "100m"  
+          memory: "128Mi"
+        limits:
+          cpu: "1000m"
+          memory: "2048Mi"
+components:
+  api:
+    admin:
+      resources:
+        requests:
+          cpu: "100m"  
+          memory: "128Mi"
+        limits:
+          cpu: "1000m"
+          memory: "1024Mi"
+    communication:
+      communication:
+        resources:
+          requests:
+            cpu: "200m"  
+            memory: "128Mi"
+          limits:
+            cpu: "2000m"
+            memory: "2048Mi"
+      websocket:
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "128Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1024Mi"
+  frontend:
+    ui:
+      resources:
+        requests:
+          cpu: "50m"  
+          memory: "64Mi"
+        limits:
+          cpu: "500m"
+          memory: "512Mi"
+  integration:
+    source-api:
+      resources:
+        requests:
+          cpu: "50m"
+          memory: "128Mi"
+        limits:
+          cpu: "1000m"
+          memory: "1024Mi"
+    webhook:
+      consumer:
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "128Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1024Mi"
+      publisher:
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "128Mi"
+          limits:
+            cpu: "1000m"
+            memory: "2048Mi"
+  media:
+    resolver:
+      resources:
+        requests:
+          cpu: "50m"
+          memory: "128Mi"
+        limits:
+          cpu: "1000m"
+          memory: "1024Mi"
+  sources:
+    chatplugin:
+      backend:
+        resources:
+          requests:
+            cpu: "50m"  
+            memory: "128Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1024Mi"
+      frontend:
+        resources:
+          requests:
+            cpu: "50m"  
+            memory: "64Mi"
+          limits:
+            cpu: "500m"
+            memory: "1024Mi"
+    facebook:
+      connector:
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1024Mi"
+      eventsRouter:
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "128Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1024Mi"
+    google:
+      connector:
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1024Mi"
+      eventsRouter:
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "128Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1024Mi"
+    twilio:
+      connector:
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1024Mi"
+      eventsRouter:
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "128Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1024Mi"
+    viber:
+      connector:
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1024Mi"
+      eventsRouter:
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "128Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1024Mi"

--- a/infrastructure/helm-chart/templates/controller/deployment.yaml
+++ b/infrastructure/helm-chart/templates/controller/deployment.yaml
@@ -30,3 +30,10 @@ spec:
           value: "core.airy.co/managed=true"
         - name: NAMESPACE
           value: {{ .Release.Namespace }}
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "32Mi"
+          limits:
+            cpu: "50m"
+            memory: "128Mi"

--- a/infrastructure/helm-chart/templates/resources/limitRange.yaml
+++ b/infrastructure/helm-chart/templates/resources/limitRange.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.limitRange }}
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: {{ .Release.Namespace }}
+spec:
+  limits:
+  - default:
+      cpu: "50m"
+      memory: "128Mi"
+    defaultRequest:
+      cpu: "20m"
+      memory: "32Mi"
+    type: Container
+{{ end }}

--- a/infrastructure/helm-chart/values.yaml
+++ b/infrastructure/helm-chart/values.yaml
@@ -19,3 +19,4 @@ tools:
     enabled: true
 serviceAccount: airy-admin
 apiHost: http://airy.core
+limitRange: false


### PR DESCRIPTION
Create requests and limits for cpu and memory of all of the components.
Create a default rangeLimit for other pods/containers running in the namespace where Airy is deployed (disabled by default).

The apps ship with some default values for requests and limits. They can be overwritten in the `airy.yaml` file and applied with `airy upgrade`.

When deploying with `helm`, an alternative file can be used specifying all the requests and limits for all of the components.
https://github.com/airyhq/airy/pull/2505/files#diff-6803230d31353ceae0bc72bdb2959f67a73f97ce01816b8acf537911613058f9

That file can be invoked as:
```
helm install airy chart-url --values ./airy.yaml --values ./requests.yaml
```
Having a separate values file, will facilitate creating profiles (light, moderate, heavy) in the future, that can be applied on depending the size and the traffic of the Airy cluster.