### PR TITLE
[#2504] fix emoji reaction styling

### DIFF
--- a/lib/typescript/components/message/Reaction/index.module.scss
+++ b/lib/typescript/components/message/Reaction/index.module.scss
@@ -7,7 +7,7 @@
   align-items: center;
   justify-content: flex-end;
   padding-right: 8px;
-  margin-top: -5px;
+  margin-top: -14px;
 }
 
 .emojiWrapper {
@@ -15,5 +15,5 @@
   background-color: var(--color-light-gray);
   width: 24px;
   height: 24px;
-  text-align: center;
+  padding-left: 4px;
 }


### PR DESCRIPTION
closes #2504 

**screenshots:**

_before_
<img width="229" alt="Screenshot 2021-10-19 at 09 49 30" src="https://user-images.githubusercontent.com/38159391/137866486-340faa02-fafb-4df6-85ad-9d16407b7b75.png">

_after_
<img width="320" alt="Screenshot 2021-10-19 at 09 45 10" src="https://user-images.githubusercontent.com/38159391/137867460-158ae15d-4ec2-402f-b770-d7e6c3e4b735.png">

