### PR TITLE
[ #2514] fixed ui bugs

### DIFF
--- a/frontend/ui/src/pages/Inbox/MessageInput/InputSelector.tsx
+++ b/frontend/ui/src/pages/Inbox/MessageInput/InputSelector.tsx
@@ -3,22 +3,24 @@ import styles from './InputSelector.module.scss';
 import {ReactComponent as Close} from 'assets/images/icons/close.svg';
 import {SourceMessage} from 'render';
 import {Source, Message} from 'model';
+import {FileInfo} from './index';
 
 type InputSelectorProps = {
   messageType: 'template' | 'suggestedReplies' | 'message';
   message: Message;
   source: Source;
   contentResizedHeight: number;
+  fileInfo: FileInfo | null;
   removeElementFromInput: () => void;
 };
 
 export const InputSelector = (props: InputSelectorProps) => {
-  const {source, message, messageType, removeElementFromInput, contentResizedHeight} = props;
+  const {source, message, messageType, removeElementFromInput, contentResizedHeight, fileInfo} = props;
   const [closeIconWidth, setCloseIconWidth] = useState('');
   const [closeIconHeight, setCloseIconHeight] = useState('');
+  const [closeButtonSelector, setCloseButtonSelector] = useState(false);
 
-  const removeSelectedButton = useRef(null);
-  const fileSelectorDiv = useRef<HTMLDivElement>(null);
+  const fileSelectorDiv = useRef(null);
   const removeFileButton = useRef(null);
 
   const scaleInputSelector = () => {
@@ -32,15 +34,30 @@ export const InputSelector = (props: InputSelectorProps) => {
 
         setCloseIconHeight(iconSize);
         setCloseIconWidth(iconSize);
+        setCloseButtonSelector(true);
 
         if (removeFileButton && removeFileButton.current) {
           removeFileButton.current.style.width = buttonSize;
           removeFileButton.current.style.height = buttonSize;
         }
+      } else {
+        setCloseButtonSelector(true);
       }
 
       fileSelectorDiv.current.style.transform = `scale(${scaleRatio})`;
       fileSelectorDiv.current.style.transformOrigin = 'left';
+    } else {
+      if (fileInfo && fileInfo?.size >= 1 && fileInfo?.type !== 'audio' && fileInfo?.type !== 'file') {
+        setTimeout(() => {
+          setCloseButtonSelector(true);
+        }, 1000);
+      } else if (fileInfo && fileInfo?.size < 1 && fileInfo?.type !== 'audio' && fileInfo?.type !== 'file') {
+        setTimeout(() => {
+          setCloseButtonSelector(true);
+        }, 500);
+      } else {
+        setCloseButtonSelector(true);
+      }
     }
   };
 
@@ -50,14 +67,16 @@ export const InputSelector = (props: InputSelectorProps) => {
 
   return (
     <div className={styles.container} ref={fileSelectorDiv}>
-      <button className={styles.removeButton} onClick={removeElementFromInput} ref={removeSelectedButton}>
-        <Close
-          style={{
-            width: closeIconWidth ?? '',
-            height: closeIconHeight ?? '',
-          }}
-        />
-      </button>
+      {closeButtonSelector && (
+        <button className={styles.removeButton} onClick={removeElementFromInput} ref={removeFileButton}>
+          <Close
+            style={{
+              width: closeIconWidth ?? '',
+              height: closeIconHeight ?? '',
+            }}
+          />
+        </button>
+      )}
       <SourceMessage message={message} source={source} contentType={messageType} />
     </div>
   );

--- a/frontend/ui/src/pages/Inbox/Messenger/MessengerContainer/index.tsx
+++ b/frontend/ui/src/pages/Inbox/Messenger/MessengerContainer/index.tsx
@@ -97,10 +97,10 @@ const MessengerContainer = ({
   };
 
   const handleDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
+    if (dragAndDropDisabled) return;
+
     event.preventDefault();
     event.stopPropagation();
-
-    if (dragAndDropDisabled) return;
 
     dragCounter++;
 
@@ -108,10 +108,11 @@ const MessengerContainer = ({
   };
 
   const handleFileDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    if (dragAndDropDisabled) return;
+
     event.preventDefault();
     event.stopPropagation();
 
-    if (dragAndDropDisabled) return;
     dragCounter++;
     const file = event.dataTransfer.files[0];
     setDraggedAndDroppedFile(file);
@@ -119,10 +120,10 @@ const MessengerContainer = ({
   };
 
   const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+    if (dragAndDropDisabled) return;
     event.preventDefault();
     event.stopPropagation();
 
-    if (dragAndDropDisabled) return;
     dragCounter--;
     if (dragCounter === 0) {
       setIsFileDragged(false);
@@ -164,6 +165,7 @@ const MessengerContainer = ({
                   source={currentConversation.channel.source as Source}
                   draggedAndDroppedFile={draggedAndDroppedFile}
                   setDraggedAndDroppedFile={setDraggedAndDroppedFile}
+                  setDragAndDropDisabled={setDragAndDropDisabled}
                 />
               </>
             )}

--- a/lib/typescript/render/attachments.ts
+++ b/lib/typescript/render/attachments.ts
@@ -9,6 +9,7 @@ export const fileExtensions = [
   'docx',
   'rtf',
   'tex',
+  'txt',
   'wpd',
   'psd',
   'svg',

--- a/lib/typescript/render/components/Image/index.module.scss
+++ b/lib/typescript/render/components/Image/index.module.scss
@@ -15,5 +15,6 @@
 
 .messageListItemImageBlock {
   max-height: 200px;
+  max-width: 300px;
   border-radius: 8px;
 }

--- a/lib/typescript/render/components/ImageWithFallback/index.tsx
+++ b/lib/typescript/render/components/ImageWithFallback/index.tsx
@@ -4,6 +4,7 @@ type ImageRenderProps = {
   src: string;
   alt?: string;
   className?: string;
+  isTemplate?: boolean;
 };
 
 /**
@@ -14,7 +15,7 @@ type ImageRenderProps = {
  */
 const failedUrls = [];
 
-export const ImageWithFallback = ({src, alt, className}: ImageRenderProps) => {
+export const ImageWithFallback = ({src, alt, className, isTemplate}: ImageRenderProps) => {
   const [imageFailed, setImageFailed] = useState(failedUrls.includes(src));
 
   useEffect(() => {
@@ -27,13 +28,24 @@ export const ImageWithFallback = ({src, alt, className}: ImageRenderProps) => {
   };
 
   return (
-    <a href={src} target="_blank" rel="noopener noreferrer">
-      <img
-        className={className}
-        src={imageFailed ? 'https://s3.amazonaws.com/assets.airy.co/fallbackMediaImage.svg' : src}
-        alt={imageFailed ? 'The image failed to load' : alt}
-        onError={() => loadingFailed()}
-      />
-    </a>
+    <>
+      {isTemplate ? (
+        <img
+          className={className}
+          src={imageFailed ? 'https://s3.amazonaws.com/assets.airy.co/fallbackMediaImage.svg' : src}
+          alt={imageFailed ? 'The image failed to load' : alt}
+          onError={() => loadingFailed()}
+        />
+      ) : (
+        <a href={src} target="_blank" rel="noopener noreferrer">
+          <img
+            className={className}
+            src={imageFailed ? 'https://s3.amazonaws.com/assets.airy.co/fallbackMediaImage.svg' : src}
+            alt={imageFailed ? 'The image failed to load' : alt}
+            onError={() => loadingFailed()}
+          />
+        </a>
+      )}
+    </>
   );
 };

--- a/lib/typescript/render/index.ts
+++ b/lib/typescript/render/index.ts
@@ -2,3 +2,4 @@ export * from './props';
 export * from './SourceMessage';
 export * from './SourceMessagePreview';
 export * from './outbound';
+export * from './attachments';

--- a/lib/typescript/render/providers/chatplugin/components/QuickReplies/index.tsx
+++ b/lib/typescript/render/providers/chatplugin/components/QuickReplies/index.tsx
@@ -44,9 +44,14 @@ export const QuickReplies = ({
 
       <div className={styles.container}>
         {quickReplies.map((reply: QuickReply) => (
-          <button key={reply.title} className={styles.replyButton} onClick={() => clickPostback(reply)}>
+          <button type="button" key={reply.title} className={styles.replyButton} onClick={() => clickPostback(reply)}>
             {reply.image_url && (
-              <ImageWithFallback className={styles.quickReplyImage} alt={reply.title} src={reply.image_url} />
+              <ImageWithFallback
+                className={styles.quickReplyImage}
+                alt={reply.title}
+                src={reply.image_url}
+                isTemplate
+              />
             )}
             <h1 key={reply.title} className={styles.title}>
               {reply.title}

--- a/lib/typescript/render/providers/chatplugin/components/RichCard/Media/index.tsx
+++ b/lib/typescript/render/providers/chatplugin/components/RichCard/Media/index.tsx
@@ -28,5 +28,5 @@ const getHeight = (height: MediaHeight): string => {
 };
 
 export const Media = ({height, contentInfo: {altText, fileUrl}}: MediaRenderProps) => (
-  <ImageWithFallback src={fileUrl} alt={altText} className={`${styles.mediaImage} ${getHeight(height)}`} />
+  <ImageWithFallback src={fileUrl} alt={altText} className={`${styles.mediaImage} ${getHeight(height)}`} isTemplate />
 );

--- a/lib/typescript/render/providers/facebook/components/GenericTemplate/index.tsx
+++ b/lib/typescript/render/providers/facebook/components/GenericTemplate/index.tsx
@@ -16,7 +16,9 @@ export const GenericTemplate = ({template}: GenericTemplateRendererProps) => {
     <Carousel>
       {template.elements.map((element, idx) => (
         <div key={`template-${idx}`} className={styles.template}>
-          {element.image_url?.length && <ImageWithFallback className={styles.templateImage} src={element.image_url} />}
+          {element.image_url?.length && (
+            <ImageWithFallback className={styles.templateImage} src={element.image_url} isTemplate />
+          )}
           <div className={styles.innerTemplate}>
             <div className={styles.templateTitle}>{element.title}</div>
             <div className={styles.templateSubtitle}>{element.subtitle}</div>

--- a/lib/typescript/render/providers/facebook/components/QuickReplies/index.tsx
+++ b/lib/typescript/render/providers/facebook/components/QuickReplies/index.tsx
@@ -27,8 +27,8 @@ export const QuickReplies = ({quickReplies, fromContact, text, attachment}: Quic
 
     <div className={styles.container}>
       {quickReplies.map(({title, image_url: imageUrl}) => (
-        <button key={title} className={styles.replyButton}>
-          {imageUrl && <ImageWithFallback className={styles.quickReplyImage} alt={title} src={imageUrl} />}
+        <button type="button" key={title} className={styles.replyButton}>
+          {imageUrl && <ImageWithFallback className={styles.quickReplyImage} alt={title} src={imageUrl} isTemplate />}
           <h1 key={title} className={styles.title}>
             {title}
           </h1>

--- a/lib/typescript/render/providers/google/components/RichCard/Media/index.tsx
+++ b/lib/typescript/render/providers/google/components/RichCard/Media/index.tsx
@@ -28,5 +28,5 @@ const getHeight = (height: MediaHeight): string => {
 };
 
 export const Media = ({height, contentInfo: {altText, fileUrl}}: MediaRenderProps) => (
-  <ImageWithFallback src={fileUrl} alt={altText} className={`${styles.mediaImage} ${getHeight(height)}`} />
+  <ImageWithFallback src={fileUrl} alt={altText} className={`${styles.mediaImage} ${getHeight(height)}`} isTemplate />
 );

--- a/lib/typescript/render/providers/google/components/Suggestions/index.tsx
+++ b/lib/typescript/render/providers/google/components/Suggestions/index.tsx
@@ -30,7 +30,7 @@ export const Suggestions = ({text, fallback, image, suggestions, fromContact}: S
       {(suggestions as SuggestionsUnion[]).map(elem => {
         if ('reply' in elem) {
           return (
-            <button key={elem.reply.text} className={styles.replyButton}>
+            <button type="button" key={elem.reply.text} className={styles.replyButton}>
               <h1 key={elem.reply.text} className={styles.title}>
                 {elem.reply.text}
               </h1>
@@ -40,7 +40,7 @@ export const Suggestions = ({text, fallback, image, suggestions, fromContact}: S
 
         if ('action' in elem) {
           return (
-            <button key={elem.action.text} className={styles.replyButton}>
+            <button type="button" key={elem.action.text} className={styles.replyButton}>
               <img
                 className={styles.actionImage}
                 alt={elem.action.openUrlAction ? 'link icon' : 'phone icon'}
@@ -66,7 +66,7 @@ export const Suggestions = ({text, fallback, image, suggestions, fromContact}: S
 
         if ('authenticationRequest' in elem) {
           return (
-            <button key={elem.authenticationRequest.oauth.clientId} className={styles.replyButton}>
+            <button type="button" key={elem.authenticationRequest.oauth.clientId} className={styles.replyButton}>
               <h1 key={elem.authenticationRequest.oauth.clientId} className={styles.title}>
                 Authenticate with Google
               </h1>
@@ -76,7 +76,7 @@ export const Suggestions = ({text, fallback, image, suggestions, fromContact}: S
 
         if ('liveAgentRequest' in elem) {
           return (
-            <button key={Math.floor(Math.random() * 50)} className={styles.replyButton}>
+            <button type="button" key={Math.floor(Math.random() * 50)} className={styles.replyButton}>
               <h1 key={Math.floor(Math.random() * 50)} className={styles.title}>
                 Message a live agent on Google&apos;s Business Messages
               </h1>


### PR DESCRIPTION
closes #2514 

fixed UI bugs:
- images within templates are clickable (only attachment images should be)
- some buttons in the render library refresh the page (QuickReplies for ex.)
- small bugs when loading big images in the input selector (the close button is added before the image is loaded)
- drag and drop should be disabled if a file or template has already been selected