### PR TITLE
Add CLI outdated version warning

### DIFF
--- a/cli/integration/version_test.go
+++ b/cli/integration/version_test.go
@@ -12,7 +12,7 @@ func TestVersion(t *testing.T) {
 	}
 
 	// https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-	validVersionString := regexp.MustCompile(`^Version: (develop|(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?), GitCommit: [0-9a-f]{5,40}\n$`)
+	validVersionString := regexp.MustCompile(`Version: (develop|(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?), GitCommit: [0-9a-f]{5,40}\n$`)
 
 	if !validVersionString.MatchString(actual) {
 		t.Errorf("expected %s to be a valid version but was not", actual)

--- a/cli/pkg/cmd/root.go
+++ b/cli/pkg/cmd/root.go
@@ -9,7 +9,12 @@ import (
 	"cli/pkg/cmd/upgrade"
 	"cli/pkg/workspace"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
+	"regexp"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -17,6 +22,7 @@ import (
 
 const cliConfigFileName = "cli.yaml"
 const cliConfigDirName = ".airy"
+const cliVersionAPI = "https://airy-core-binaries.s3.amazonaws.com/stable.txt"
 
 var cliConfigDir string
 var Version string
@@ -31,7 +37,35 @@ var RootCmd = &cobra.Command{
 		if cmd.Name() != "create" && cmd.Name() != "version" {
 			workspace.Init(cliConfigDir)
 		}
+		if !strings.Contains(Version, "alpha") {
+			cliVersion()
+		}
 	},
+}
+
+func cliVersion() {
+	latest_stable := Version
+	client := http.Client{
+		Timeout: time.Second,
+	}
+
+	resp, err := client.Get(cliVersionAPI)
+	if err != nil {
+		return
+	} else {
+		body, _ := ioutil.ReadAll(resp.Body)
+		defer resp.Body.Close()
+		temp := strings.TrimSuffix(string(body), "\n")
+		match, _ := regexp.MatchString("^[0-9]+\\.[0-9]+\\.[0-9]+$", temp)
+		if match {
+			latest_stable = temp
+		} else {
+			return
+		}
+	}
+	if Version != latest_stable {
+		fmt.Printf("Warning: Your CLI version is out of date. Please upgrade to the latest stable version: %s. \n\n", latest_stable)
+	}
 }
 
 var versionCmd = &cobra.Command{


### PR DESCRIPTION
Resolves #2305.

When the user issues any airy command in the cli, they will get a warning if their version is different from the latest stable release.

![image](https://user-images.githubusercontent.com/91729991/138879213-f6fb2b1d-f095-4405-bcca-8641c59c2e94.png)
