### PR TITLE
[2457] Fix upgrade to same version

### DIFF
--- a/cli/pkg/helm/helm.go
+++ b/cli/pkg/helm/helm.go
@@ -89,6 +89,7 @@ func (h *Helm) UpgradeCharts() error {
 	chartURL := "https://airy-core-helm-charts.s3.amazonaws.com/stable/airy-" + h.version + ".tgz"
 	return h.runHelm(append([]string{"upgrade",
 		"--values", "/apps/config/airy-config-map.yaml",
+		"--namespace", h.namespace,
 		"--timeout", "10m0s",
 		"airy", chartURL}))
 }

--- a/infrastructure/helm-chart/templates/controller/deployment.yaml
+++ b/infrastructure/helm-chart/templates/controller/deployment.yaml
@@ -18,6 +18,8 @@ spec:
     metadata:
       labels:
         app: airy-controller
+      annotations:
+        releaseTime: {{ (now) | toString | trunc 28 | quote }}
     spec:
       serviceAccountName: airy-controller
       automountServiceAccountToken: true


### PR DESCRIPTION
Making sure that the controller restarts on upgrade, so that it starts all the components, for which there are already config maps.
