### PR TITLE
[#2518] Add terraform code for core deployment

### DIFF
--- a/cli/pkg/helm/helm.go
+++ b/cli/pkg/helm/helm.go
@@ -79,7 +79,7 @@ func (h *Helm) Setup() error {
 }
 
 func (h *Helm) InstallCharts() error {
-	chartURL := "https://airy-core-helm-charts.s3.amazonaws.com/stable/airy-" + h.version + ".tgz"
+	chartURL := "https://airy-core-helm-charts.s3.amazonaws.com/stable/airy-0.33.0.tgz"
 	return h.runHelm(append([]string{"install",
 		"--values", "/apps/config/airy-config-map.yaml",
 		"--namespace", h.namespace,

--- a/docs/docs/getting-started/installation/introduction.md
+++ b/docs/docs/getting-started/installation/introduction.md
@@ -7,6 +7,7 @@ import TLDR from "@site/src/components/TLDR";
 import ButtonBoxList from "@site/src/components/ButtonBoxList";
 import ButtonBox from "@site/src/components/ButtonBox";
 import AwsSVG from "@site/static/icons/aws.svg";
+import TerraformSVG from "@site/static/icons/terraform.svg";
 import Minikube from "@site/static/icons/minikube.svg";
 import RocketSVG from "@site/static/icons/rocket.svg";
 import HelmSVG from "@site/static/icons/helm.svg";
@@ -60,5 +61,11 @@ icon={<AwsSVG />}
 title='Production ready environment with AWS'
 description='Step by step guide to run Airy Core on AWS'
 link='getting-started/installation/aws'
+/>
+<ButtonBox
+icon={<TerraformSVG />}
+title='Cloud deployment with Terraform'
+description='Step by step guide to run Airy Core in the cloud managed by Terraform'
+link='getting-started/installation/terraform'
 />
 </ButtonBoxList>

--- a/docs/docs/getting-started/installation/terraform.md
+++ b/docs/docs/getting-started/installation/terraform.md
@@ -1,0 +1,54 @@
+---
+title: Run Airy Core on AWS with Terraform
+sidebar_label: Terraform
+---
+
+## Requirements
+
+- [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) v1.0.0+
+- [Airy CLI](https://airy.co/docs/core/cli/introduction) v0.34.0+
+- [SSH key](https://www.ssh.com/academy/ssh/keygen) in `~/.ssh/id_rsa.pub`
+- [Kubectl](https://kubernetes.io/docs/tasks/tools/) (optional)
+
+## Create the Kubernetes cluster
+
+In case you already have a cluster running you can skip to the next section.
+
+### Amazon Web Services
+
+You need to provide Terraform with the AWS credentials for your IAM Role. If
+you don't know how to create one, [follow these
+instructions](https://aws.amazon.com/premiumsupport/knowledge-center/create-access-key/).
+They have to be put into a `terraform.tfvars` file in `terraform/kubernetes` that looks contains:
+
+```
+aws_access_key = "<YOUR_AWS_ACCESS_KEY>"
+aws_secret_key = "<YOUR_AWS_SECRET_KEY>"
+```
+
+If you want to deploy the EKS cluster in your existing VPC you have to override the
+`vpc_id`, `subnets` and `fargate_subnets` variables with the outputs from your
+vpc and set `create_vpc=false` in the Airy Core module.
+
+```
+terraform init
+terraform apply
+```
+
+## Install Airy Helm chart
+
+After the Kubernetes cluster has been created we can deploy the Airy Helm chart
+to it. Change to the `terraform/main` directory and make sure the `.kubeconfig`
+file is there.
+
+You can [configure](https://airy.co/docs/core/getting-started/installation/configuration) your instance by making changes to `infrastructure/terraform/main/files/values.yaml`
+
+If you want to deploy the stateless apps with AWS Fargate you can add
+`workerType: fargate` to the `values.yaml`
+
+Finally, you need to initialize the Terraform workspace and run apply.
+
+```
+terraform init
+terraform apply
+```

--- a/docs/static/icons/terraform.svg
+++ b/docs/static/icons/terraform.svg
@@ -1,0 +1,1 @@
+<svg width="24px" height="24px" viewBox="0 0 24 24" role="img" xmlns="http://www.w3.org/2000/svg"><title>Terraform icon</title><path d="M8.283 4.265l7.433 3.776v7.551l-7.433-3.776V4.265zm8.248 3.776v7.551l7.436-3.776V4.265l-7.436 3.776zM.035.051v7.551l7.433 3.776V3.827L.035.051zm8.248 20.141l7.433 3.776V16.42l-7.433-3.776v7.548z"/></svg>

--- a/infrastructure/helm-chart/charts/components/charts/api/charts/api-communication/templates/communication/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/api/charts/api-communication/templates/communication/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels:
         app: api-communication
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
       - name: app
@@ -54,7 +54,7 @@ spec:
             httpHeaders:
             - name: Health-Check
               value: health-check
-          initialDelaySeconds: 60
+          initialDelaySeconds: 120
           periodSeconds: 10
           failureThreshold: 3
         resources:

--- a/infrastructure/helm-chart/charts/components/charts/api/charts/api-communication/templates/websocket/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/api/charts/api-communication/templates/websocket/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels:
         app: api-websocket
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
       - name: app
@@ -54,7 +54,7 @@ spec:
             httpHeaders:
             - name: Health-Check
               value: health-check
-          initialDelaySeconds: 60
+          initialDelaySeconds: 120
           periodSeconds: 10
           failureThreshold: 3
         resources:

--- a/infrastructure/helm-chart/charts/components/charts/frontend/charts/frontend-ui/templates/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/frontend/charts/frontend-ui/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       labels:
         app: frontend-ui
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
       - name: app

--- a/infrastructure/helm-chart/charts/components/charts/integration/charts/source-api/templates/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/integration/charts/source-api/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
             httpHeaders:
               - name: Health-Check
                 value: health-check
-          initialDelaySeconds: 60
+          initialDelaySeconds: 120
           periodSeconds: 10
           failureThreshold: 3
         resources:

--- a/infrastructure/helm-chart/charts/components/charts/integration/charts/webhook/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/integration/charts/webhook/templates/deployments.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels:
         app: webhook-consumer
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
       - name: app
@@ -66,7 +66,7 @@ spec:
             httpHeaders:
               - name: Health-Check
                 value: health-check
-          initialDelaySeconds: 60
+          initialDelaySeconds: 120
         resources:
 {{ toYaml .Values.consumer.resources | indent 10 }}
       initContainers:
@@ -117,7 +117,7 @@ spec:
     metadata:
       labels:
         app: webhook-publisher
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
       - name: app
@@ -163,7 +163,7 @@ spec:
             httpHeaders:
               - name: Health-Check
                 value: health-check
-          initialDelaySeconds: 60
+          initialDelaySeconds: 120
         resources:
 {{ toYaml .Values.publisher.resources | indent 10 }}
       initContainers:

--- a/infrastructure/helm-chart/charts/components/charts/media/charts/resolver/templates/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/media/charts/resolver/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels:
         app: media-resolver
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
         - name: app
@@ -56,7 +56,7 @@ spec:
               httpHeaders:
                 - name: Health-Check
                   value: health-check
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
             periodSeconds: 10
             failureThreshold: 3
           resources:

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/templates/backend/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/templates/backend/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels:
         app: sources-chatplugin
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
       - name: app
@@ -64,7 +64,7 @@ spec:
             httpHeaders:
               - name: Health-Check
                 value: health-check
-          initialDelaySeconds: 60
+          initialDelaySeconds: 120
           periodSeconds: 10
           failureThreshold: 3
         resources:

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/templates/frontend/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/templates/frontend/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels:
         app: frontend-chat-plugin
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
       - name: app

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/facebook/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/facebook/templates/deployments.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels:
         app: sources-facebook-connector
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
         - name: app
@@ -71,7 +71,7 @@ spec:
               httpHeaders:
               - name: Health-Check
                 value: health-check
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
           resources:
 {{ toYaml .Values.connector.resources | indent 12 }}
       initContainers:
@@ -122,7 +122,7 @@ spec:
     metadata:
       labels:
         app: sources-facebook-events-router
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
       - name: app
@@ -154,7 +154,7 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 6000
-          initialDelaySeconds: 60
+          initialDelaySeconds: 120
           periodSeconds: 10
           failureThreshold: 3
         resources:

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/google/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/google/templates/deployments.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels:
         app: sources-google-connector
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
         - name: app
@@ -66,7 +66,7 @@ spec:
               httpHeaders:
               - name: Health-Check
                 value: health-check
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
           resources:
 {{ toYaml .Values.connector.resources | indent 12 }}
       initContainers:
@@ -117,7 +117,7 @@ spec:
     metadata:
       labels:
         app: sources-google-events-router
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
       - name: app
@@ -152,7 +152,7 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 6000
-          initialDelaySeconds: 60
+          initialDelaySeconds: 120
           periodSeconds: 10
           failureThreshold: 3
         resources:

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/twilio/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/twilio/templates/deployments.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels:
         app: sources-twilio-connector
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
         - name: app
@@ -66,7 +66,7 @@ spec:
               httpHeaders:
               - name: Health-Check
                 value: health-check
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
           resources:
 {{ toYaml .Values.connector.resources | indent 12 }}
       initContainers:
@@ -119,7 +119,7 @@ spec:
     metadata:
       labels:
         app: sources-twilio-events-router
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
       - name: app
@@ -154,7 +154,7 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 6000
-          initialDelaySeconds: 60
+          initialDelaySeconds: 120
           periodSeconds: 10
           failureThreshold: 3
         resources:

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/viber/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/viber/templates/deployments.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels:
         app: sources-viber-connector
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
         - name: app
@@ -61,7 +61,7 @@ spec:
               httpHeaders:
                 - name: Health-Check
                   value: health-check
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
           resources:
 {{ toYaml .Values.connector.resources | indent 12 }}
       initContainers:
@@ -114,7 +114,7 @@ spec:
     metadata:
       labels:
         app: sources-viber-events-router
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
         - name: app
@@ -149,7 +149,7 @@ spec:
           livenessProbe:
             tcpSocket:
               port: 6000
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
             periodSeconds: 10
             failureThreshold: 3
           resources:

--- a/infrastructure/helm-chart/charts/components/templates/api/admin/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/templates/api/admin/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels:
         app: api-admin
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
       - name: app
@@ -70,7 +70,7 @@ spec:
             httpHeaders:
             - name: Health-Check
               value: health-check
-          initialDelaySeconds: 60
+          initialDelaySeconds: 120
           periodSeconds: 10
           failureThreshold: 3
         resources:

--- a/infrastructure/helm-chart/charts/ingress-controller/templates/ingress-controller.yaml
+++ b/infrastructure/helm-chart/charts/ingress-controller/templates/ingress-controller.yaml
@@ -1,3 +1,4 @@
+{{ if index .Values "ingress-controller.enabled" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -258,3 +259,4 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 2000
+{{ end }}

--- a/infrastructure/helm-chart/charts/ingress-controller/templates/ngrok.yaml
+++ b/infrastructure/helm-chart/charts/ingress-controller/templates/ngrok.yaml
@@ -53,7 +53,6 @@ spec:
     metadata:
       labels:
         app: ngrok-proxy
-        WorkerType: fargate
     spec:
       containers:
         - name: ngrok

--- a/infrastructure/helm-chart/charts/ingress-controller/templates/service.yaml
+++ b/infrastructure/helm-chart/charts/ingress-controller/templates/service.yaml
@@ -1,3 +1,4 @@
+{{ if index  .Values "ingress-controller.enabled" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -101,4 +102,5 @@ spec:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
+{{ end }}
 {{ end }}

--- a/infrastructure/helm-chart/charts/ingress-controller/templates/serviceaccount.yaml
+++ b/infrastructure/helm-chart/charts/ingress-controller/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if index  .Values "ingress-controller.enabled" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -280,3 +281,4 @@ subjects:
   - kind: ServiceAccount
     name: ingress-nginx-admission
     namespace: {{ .Values.namespace }}
+{{ end }}

--- a/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/schema-registry/templates/deployment.yaml
+++ b/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/schema-registry/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         app: schema-registry
         release: {{ .Release.Name }}
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
         - name: schema-registry-server

--- a/infrastructure/helm-chart/charts/tools/charts/akhq/templates/deployment.yaml
+++ b/infrastructure/helm-chart/charts/tools/charts/akhq/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     metadata:
       labels:
         app: akhq
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
     spec:
       containers:
         - name: app

--- a/infrastructure/helm-chart/charts/tools/charts/kafka-connect/templates/deployment.yaml
+++ b/infrastructure/helm-chart/charts/tools/charts/kafka-connect/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       labels:
         app: {{ template "kafka-connect.name" . }}
         release: {{ .Release.Name }}
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
       {{- if or .Values.podAnnotations .Values.prometheus.jmx.enabled }}
       annotations:
       {{- range $key, $value := .Values.podAnnotations }}

--- a/infrastructure/helm-chart/templates/controller/deployment.yaml
+++ b/infrastructure/helm-chart/templates/controller/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         app: airy-controller
-        WorkerType: fargate
+        WorkerType: "{{ default "NodeGroup" .Values.global.workerType }}"
       annotations:
         releaseTime: {{ (now) | toString | trunc 28 | quote }}
     spec:

--- a/infrastructure/helm-chart/templates/provisioning/job-wait.yaml
+++ b/infrastructure/helm-chart/templates/provisioning/job-wait.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: wait-for-api-communication
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "5"
@@ -33,6 +34,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: wait-for-frontend-ui
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "5"

--- a/infrastructure/helm-chart/templates/provisioning/kafka-create-topics.yaml
+++ b/infrastructure/helm-chart/templates/provisioning/kafka-create-topics.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install, pre-upgrade"
     "helm.sh/hook-weight": "2"
+  namespace: {{ .Release.Namespace }}
 data:
   create-topics.sh: |
     #!/bin/bash

--- a/infrastructure/helm-chart/templates/provisioning/scripts.yaml
+++ b/infrastructure/helm-chart/templates/provisioning/scripts.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: provisioning-scripts
+  namespace: {{ .Release.Namespace }}
 data:
   wait-for-service.sh: |
     #!/bin/sh

--- a/infrastructure/helm-chart/templates/serviceaccount.yaml
+++ b/infrastructure/helm-chart/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.global.namespaced }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -21,3 +22,5 @@ subjects:
 - kind: ServiceAccount
   name: airy-admin
   namespace: {{ .Release.Namespace }}
+
+{{ end }}

--- a/infrastructure/terraform/kubernetes/main.tf
+++ b/infrastructure/terraform/kubernetes/main.tf
@@ -1,0 +1,29 @@
+module "eks" {
+  source = "../modules/aws_eks"
+
+  core_id = "core"
+
+
+  aws_access_key = var.aws_access_key
+  aws_secret_key = var.aws_secret_key
+
+}
+
+resource "aws_eks_fargate_profile" "example" {
+
+
+  cluster_name           = module.eks.cluster_name
+  fargate_profile_name   = "example"
+  pod_execution_role_arn = module.eks.cluster_iam_role_arn
+  subnet_ids             = module.eks.subnet_ids
+
+  dynamic "selector" {
+    for_each = var.fargate_profiles
+    content {
+      namespace = selector.value
+      labels = {
+        WorkerType = "fargate"
+      }
+    }
+  }
+}

--- a/infrastructure/terraform/kubernetes/main.tf
+++ b/infrastructure/terraform/kubernetes/main.tf
@@ -7,23 +7,6 @@ module "eks" {
   aws_access_key = var.aws_access_key
   aws_secret_key = var.aws_secret_key
 
-}
+  fargate_profiles = var.fargate_profiles
 
-resource "aws_eks_fargate_profile" "example" {
-
-
-  cluster_name           = module.eks.cluster_name
-  fargate_profile_name   = "example"
-  pod_execution_role_arn = module.eks.cluster_iam_role_arn
-  subnet_ids             = module.eks.subnet_ids
-
-  dynamic "selector" {
-    for_each = var.fargate_profiles
-    content {
-      namespace = selector.value
-      labels = {
-        WorkerType = "fargate"
-      }
-    }
-  }
 }

--- a/infrastructure/terraform/kubernetes/outputs.tf
+++ b/infrastructure/terraform/kubernetes/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_name" {
+  value = module.eks.cluster_name
+}

--- a/infrastructure/terraform/kubernetes/variables.tf
+++ b/infrastructure/terraform/kubernetes/variables.tf
@@ -1,0 +1,14 @@
+variable "aws_access_key" {
+  description = "AWS Access Key"
+}
+
+variable "aws_secret_key" {
+  description = "AWS Secret Key"
+}
+
+variable "fargate_profiles" {
+  type = map
+  default = {
+    "name" = "default"
+  }
+}

--- a/infrastructure/terraform/main/files/values.yaml
+++ b/infrastructure/terraform/main/files/values.yaml
@@ -1,0 +1,5 @@
+ingress-controller:
+  host: ${host}.${hosted_zone}
+security:
+  allowedOrigins: "*"
+apiHost: https://${host}.${hosted_zone}

--- a/infrastructure/terraform/main/files/values.yaml
+++ b/infrastructure/terraform/main/files/values.yaml
@@ -1,5 +1,0 @@
-ingress-controller:
-  host: ${host}.${hosted_zone}
-security:
-  allowedOrigins: "*"
-apiHost: https://${host}.${hosted_zone}

--- a/infrastructure/terraform/main/main.tf
+++ b/infrastructure/terraform/main/main.tf
@@ -1,10 +1,10 @@
 module "my-airy-core" {
   source  = "../modules/core"
-  values_yaml = data.template_file.values_yaml.rendered
+  values_yaml = data.template_file.airy_yaml.rendered
 }
 
-data "template_file" "values_yaml" {
-  template = file("${path.module}/files/values.yaml")
+data "template_file" "airy_yaml" {
+  template = file("${path.module}/files/airy.yaml")
 
   vars = {
     host        = var.host

--- a/infrastructure/terraform/main/main.tf
+++ b/infrastructure/terraform/main/main.tf
@@ -1,0 +1,13 @@
+module "my-airy-core" {
+  source  = "../modules/core"
+  values_yaml = data.template_file.values_yaml.rendered
+}
+
+data "template_file" "values_yaml" {
+  template = file("${path.module}/files/values.yaml")
+
+  vars = {
+    host        = var.host
+    hosted_zone = var.hosted_zone
+  }
+}

--- a/infrastructure/terraform/main/variables.tf
+++ b/infrastructure/terraform/main/variables.tf
@@ -1,0 +1,22 @@
+variable "aws_access_key" {
+  description = "AWS Access Key"
+}
+
+variable "aws_secret_key" {
+  description = "AWS Secret Key"
+}
+
+variable "core_id" {
+  default = "core"
+}
+
+variable "kubeconfig_output_path" {
+  default = "./.kubeconfig"
+}
+
+variable "host" {
+  
+}
+variable "hosted_zone" {
+  default = "airy.co"
+}

--- a/infrastructure/terraform/modules/aws_eks/main.tf
+++ b/infrastructure/terraform/modules/aws_eks/main.tf
@@ -92,3 +92,22 @@ module "eks" {
   manage_aws_auth = false
 
 }
+
+resource "aws_eks_fargate_profile" "example" {
+
+
+  cluster_name           = module.eks.cluster_name
+  fargate_profile_name   = "example"
+  pod_execution_role_arn = module.eks.cluster_iam_role_arn
+  subnet_ids             = module.eks.subnet_ids
+
+  dynamic "selector" {
+    for_each = var.fargate_profiles
+    content {
+      namespace = selector.value
+      labels = {
+        WorkerType = "fargate"
+      }
+    }
+  }
+}

--- a/infrastructure/terraform/modules/aws_eks/main.tf
+++ b/infrastructure/terraform/modules/aws_eks/main.tf
@@ -1,0 +1,94 @@
+provider "aws" {
+  region     = var.region
+  profile    = "airy-prod"
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+}
+
+locals {
+  create_vpc = var.vpc_id == null ? true : false
+}
+
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  create_vpc = local.create_vpc
+
+  name = var.vpc_name
+  cidr = "10.0.0.0/16"
+
+  azs             = ["${var.region}a", "${var.region}b", "${var.region}c"]
+  private_subnets = var.private_subnets
+  public_subnets  = var.public_subnets
+
+  enable_nat_gateway = true
+  enable_vpn_gateway = true
+
+  tags = {
+    Terraform = "true"
+  }
+}
+
+locals {
+  vpc = (
+    local.create_vpc ?
+    {
+      id              = module.vpc.vpc_id
+      private_subnets = module.vpc.private_subnets
+      public_subnets  = module.vpc.public_subnets
+    } :
+    {
+      id              = var.vpc_id
+      private_subnets = var.private_subnets
+      public_subnets  = var.public_subnets
+    }
+  )
+}
+
+module "eks" {
+  source = "terraform-aws-modules/eks/aws"
+
+
+  cluster_version        = var.cluster_version
+  cluster_name           = var.core_id
+  vpc_id                 = local.vpc.id
+  subnets                = [local.vpc.private_subnets[0], local.vpc.public_subnets[1]]
+  fargate_subnets        = [local.vpc.private_subnets[0]]
+  kubeconfig_output_path = var.kubeconfig_output_path
+  write_kubeconfig       = true
+
+  node_groups = {
+    default = {
+      desired_capacity = 1
+
+      instance_types = [var.instance_type]
+      update_config = {
+        max_unavailable_percentage = 50
+      }
+    }
+  }
+
+  fargate_profiles = {
+
+
+     default = {
+      name = "default"
+      selectors = [
+        {
+          namespace = "kube-system"
+          labels = {
+            k8s-app = "kube-dns"
+          }
+        },
+        {
+          namespace = var.namespace
+          labels = {
+            WorkerType = "fargate"
+          }
+        }
+      ]
+    }
+  }
+  manage_aws_auth = false
+
+}

--- a/infrastructure/terraform/modules/aws_eks/main.tf
+++ b/infrastructure/terraform/modules/aws_eks/main.tf
@@ -59,7 +59,7 @@ module "eks" {
 
   node_groups = {
     default = {
-      desired_capacity = 1
+      desired_capacity = var.node_group_size
 
       instance_types = [var.instance_type]
       update_config = {

--- a/infrastructure/terraform/modules/aws_eks/outputs.tf
+++ b/infrastructure/terraform/modules/aws_eks/outputs.tf
@@ -1,0 +1,19 @@
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  value = module.eks.cluster_certificate_authority_data
+}
+
+output "cluster_name" {
+  value = module.eks.cluster_id
+}
+
+output "cluster_iam_role_arn" {
+  value = module.eks.fargate_iam_role_arn
+}
+
+output "subnet_ids" {
+  value = module.vpc.private_subnets
+}

--- a/infrastructure/terraform/modules/aws_eks/variables.tf
+++ b/infrastructure/terraform/modules/aws_eks/variables.tf
@@ -69,3 +69,7 @@ variable "fargate_namespaces" {
   type = list(string)
   default = [ "default" ]
 }
+
+variable "fargate_profiles" {
+  
+}

--- a/infrastructure/terraform/modules/aws_eks/variables.tf
+++ b/infrastructure/terraform/modules/aws_eks/variables.tf
@@ -45,6 +45,10 @@ variable "instance_type" {
   default = "t3.large"
 }
 
+variable "node_group_size" {
+  default = 1
+}
+
 variable "cluster_version" {
   default = "1.21"
 }

--- a/infrastructure/terraform/modules/aws_eks/variables.tf
+++ b/infrastructure/terraform/modules/aws_eks/variables.tf
@@ -1,0 +1,67 @@
+variable "region" {
+  description = "the AWS region in which resources are created, you must set the availability_zones variable as well if you define this value to something other than the default"
+  default     = "eu-west-1"
+}
+
+variable "aws_access_key" {
+  description = "AWS Access Key"
+}
+
+variable "aws_secret_key" {
+  description = "AWS Secret Key"
+}
+
+variable "ssh_key" {
+  description = "The name of the ssh key to use, e.g. \"airytf\""
+  default     = "~/.ssh/id_rsa"
+}
+
+variable "profile" {
+  description = "AWS profile that is used for authentication"
+  default     = "airy-prod"
+}
+
+variable "vpc_id" {
+  type    = string
+  default = null
+}
+
+variable "vpc_name" {
+  default = "core_vpc"
+}
+
+variable "private_subnets" {
+  description = "Subnet ids for the EKS cluster to be created in"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+}
+
+variable "public_subnets" {
+  default = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  
+}
+
+variable "instance_type" {
+  default = "t3.large"
+}
+
+variable "cluster_version" {
+  default = "1.21"
+}
+
+variable "core_id" {
+  default = "my-core"
+}
+
+variable "namespace" {
+  default = "default"
+}
+
+variable "kubeconfig_output_path" {
+  default = "../main/.kubeconfig"
+}
+
+variable "fargate_namespaces" {
+  type = list(string)
+  default = [ "default" ]
+}

--- a/infrastructure/terraform/modules/core/main.tf
+++ b/infrastructure/terraform/modules/core/main.tf
@@ -1,0 +1,47 @@
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig_output_path
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kubeconfig_output_path
+}
+
+resource "kubernetes_namespace" "core" {
+  metadata {
+    name = var.core_id
+  }
+}
+
+data "http" "core_version" {
+  url = "https://airy-core-binaries.s3.amazonaws.com/stable.txt"
+
+  request_headers = {
+    Accept = "application/json"
+  }
+}
+
+resource "helm_release" "airy_core" {
+  name  = "airy-release"
+  chart = "https://airy-core-helm-charts.s3.amazonaws.com/testing/airy-${trimspace(data.http.core_version.body)}.tgz"
+
+  timeout = "600"
+  values = [
+    var.values_yaml
+  ]
+
+
+  namespace = var.namespaced ? var.core_id : "default"
+
+  set {
+    name = "global.appImageTag"
+    value = trimspace(data.http.core_version.body)
+  }
+
+  depends_on = [
+    kubernetes_namespace.core
+  ]
+
+}
+

--- a/infrastructure/terraform/modules/core/outputs.tf
+++ b/infrastructure/terraform/modules/core/outputs.tf
@@ -1,0 +1,3 @@
+output "core_id" {
+  value = var.core_id
+}

--- a/infrastructure/terraform/modules/core/variables.tf
+++ b/infrastructure/terraform/modules/core/variables.tf
@@ -1,0 +1,19 @@
+variable "kubeconfig_output_path" {
+  default = "./.kubeconfig"
+}
+
+variable "kubernetes_namespace" {
+  default = "default"
+}
+
+variable "core_id" {
+  default = "airy-core"
+}
+
+variable "namespaced" {
+  default = false
+}
+
+variable "values_yaml" {
+  
+}

--- a/infrastructure/tools/topics/src/main/java/co/airy/tools/topics/Application.java
+++ b/infrastructure/tools/topics/src/main/java/co/airy/tools/topics/Application.java
@@ -27,6 +27,8 @@ public class Application {
                 "\n" +
                 "    \"helm.sh/hook-weight\": \"2\"" +
                 "\n" +
+                "  namespace: {{ .Release.Namespace }}" +
+                "\n" +
                 "data:" +
                 "\n" +
                 "  create-topics.sh: |" +


### PR DESCRIPTION
This PR adds:

- Airy Core Terraform module that creates a Helm deployment of the Airy Core helm chart in an existing Kubernetes cluster
- AWS EKS module that optionally also creates a VPC where the cluster will reside
- Ability to run Airy Core stateless apps on AWS Fargate