### PR TITLE
[#2576] Render Survey response Google Business Messages 

### DIFF
--- a/lib/typescript/render/SourceMessagePreview.tsx
+++ b/lib/typescript/render/SourceMessagePreview.tsx
@@ -6,6 +6,8 @@ import {ReactComponent as AttachmentAudio} from 'assets/images/icons/file-audio.
 import {ReactComponent as AttachmentFile} from 'assets/images/icons/file-download.svg';
 import {ReactComponent as RichCardIcon} from 'assets/images/icons/richCardIcon.svg';
 import {Conversation, Message} from 'model';
+import {Emoji} from 'components';
+
 interface SourceMessagePreviewProps {
   conversation: Conversation;
 }
@@ -35,6 +37,24 @@ export const SourceMessagePreview = (props: SourceMessagePreviewProps) => {
 
   const lastMessageIsText = (conversation: Conversation) => {
     const lastMessageContent = conversation.lastMessage.content;
+    const googleLiveAgentRequest = lastMessageContent?.userStatus?.requestedLiveAgent;
+    const googleSurveyResponse = lastMessageContent?.surveyResponse;
+
+    if (googleLiveAgentRequest) {
+      return (
+        <>
+          <Emoji symbol={'👋'} /> Live Agent request
+        </>
+      );
+    }
+
+    if (googleSurveyResponse) {
+      return (
+        <>
+          <Emoji symbol={'📝'} /> Survey response
+        </>
+      );
+    }
 
     if (typeof lastMessageContent === 'string') {
       if (lastMessageContent.includes('&Body=' && '&FromCountry=')) {

--- a/lib/typescript/render/providers/google/GoogleRender.tsx
+++ b/lib/typescript/render/providers/google/GoogleRender.tsx
@@ -9,6 +9,7 @@ import {Suggestions} from './components/Suggestions';
 import {RichCard} from './components/RichCard';
 import {RichCardCarousel} from './components/RichCardCarousel';
 import {RequestedLiveAgent} from './components/RequestedLiveAgent';
+import {SurveyResponse} from './components/SurveyResponse';
 
 export const GoogleRender = (props: RenderPropsUnion) => {
   const message = props.message;
@@ -23,6 +24,9 @@ function render(content: ContentUnion, props: RenderPropsUnion) {
 
     case 'requestedLiveAgent':
       return <RequestedLiveAgent />;
+
+    case 'surveyResponse':
+      return <SurveyResponse rating={content.rating} />;
 
     case 'image':
       return <Image imageUrl={content.imageUrl} altText="image sent via GBM" />;
@@ -122,9 +126,18 @@ function googleInbound(message): ContentUnion {
     };
   }
 
-  if (messageJson?.userStatus?.requestedLiveAgent === undefined) {
+  if (messageJson?.userStatus?.requestedLiveAgent) {
     return {
       type: 'requestedLiveAgent',
+    };
+  }
+
+  if (messageJson?.surveyResponse) {
+    const userResponse =
+      messageJson?.surveyResponse?.questionResponsePostbackData ?? messageJson?.surveyResponse?.questionResponseText;
+    return {
+      type: 'surveyResponse',
+      rating: userResponse,
     };
   }
 

--- a/lib/typescript/render/providers/google/components/SurveyResponse/index.module.scss
+++ b/lib/typescript/render/providers/google/components/SurveyResponse/index.module.scss
@@ -1,0 +1,10 @@
+.text {
+  display: inline-block;
+  max-width: 500px;
+  padding: 10px;
+  margin-top: 5px;
+  border-radius: 8px;
+  font-family: 'Lato', sans-serif;
+  background: var(--color-template-gray);
+  color: var(--color-text-contrast);
+}

--- a/lib/typescript/render/providers/google/components/SurveyResponse/index.tsx
+++ b/lib/typescript/render/providers/google/components/SurveyResponse/index.tsx
@@ -5,6 +5,7 @@ import {Emoji} from 'components';
 
 export const SurveyResponse = ({rating}) => (
   <span className={styles.text}>
-    <Emoji symbol={'📝'} /> This user has responded &#39;{rating}&#39; to a survey.
+    <Emoji symbol={'📝'} /> This user {rating === 'NO' ? 'negatively' : rating === 'YES' ? 'positively' : ''} rated the
+    experience with the response &#39;{rating}&#39;.
   </span>
 );

--- a/lib/typescript/render/providers/google/components/SurveyResponse/index.tsx
+++ b/lib/typescript/render/providers/google/components/SurveyResponse/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import styles from './index.module.scss';
+import {Emoji} from 'components';
+
+export const SurveyResponse = ({rating}) => (
+  <span className={styles.text}>
+    <Emoji symbol={'📝'} /> This user has responded '{rating}' to a survey.
+  </span>
+);

--- a/lib/typescript/render/providers/google/components/SurveyResponse/index.tsx
+++ b/lib/typescript/render/providers/google/components/SurveyResponse/index.tsx
@@ -5,6 +5,6 @@ import {Emoji} from 'components';
 
 export const SurveyResponse = ({rating}) => (
   <span className={styles.text}>
-    <Emoji symbol={'📝'} /> This user has responded '{rating}' to a survey.
+    <Emoji symbol={'📝'} /> This user has responded &#39;{rating}&#39; to a survey.
   </span>
 );

--- a/lib/typescript/render/providers/google/googleModel.ts
+++ b/lib/typescript/render/providers/google/googleModel.ts
@@ -4,11 +4,16 @@ export enum MediaHeight {
   tall = 'TALL',
 }
 export interface Content {
-  type: 'text' | 'image' | 'suggestions' | 'richCard' | 'richCardCarousel' | 'requestedLiveAgent';
+  type: 'text' | 'image' | 'suggestions' | 'richCard' | 'richCardCarousel' | 'requestedLiveAgent' | 'surveyResponse';
 }
 
 export interface RequestedLiveAgent extends Content {
   type: 'requestedLiveAgent';
+}
+
+export interface SurveyResponse extends Content {
+  type: 'surveyResponse';
+  rating: string;
 }
 
 export interface Text extends Content {
@@ -111,4 +116,11 @@ export interface Suggestions extends Content {
   suggestions: SuggestionsUnion[];
 }
 
-export type ContentUnion = Text | Image | Suggestions | RichCard | RichCardCarousel | RequestedLiveAgent;
+export type ContentUnion =
+  | Text
+  | Image
+  | Suggestions
+  | RichCard
+  | RichCardCarousel
+  | RequestedLiveAgent
+  | SurveyResponse;


### PR DESCRIPTION
closes #2576 

**changes** 
- added SurveyResponse rendering + lastMessage preview 
- fixed rendering of RequestLiveAgent + lastMessage preview 

SURVEY RESPONSE

<img width="534" alt="Screenshot 2021-11-15 at 12 14 47" src="https://user-images.githubusercontent.com/38159391/141772728-6f9d386a-6056-4b20-a533-6eb55a6d1726.png">




LIVE REQUEST AGENT
<img width="1015" alt="Screenshot 2021-11-12 at 11 50 36" src="https://user-images.githubusercontent.com/38159391/141455468-de6905ad-5d83-4110-b4b3-9d05e218475e.png">


