### PR TITLE
[#1246] Add documentation on how to run images locally

### DIFF
--- a/docs/docs/guides/contributing.md
+++ b/docs/docs/guides/contributing.md
@@ -111,6 +111,52 @@ Bazel also offers a friendly and powerful autocompletion, please refer to [this
 document](https://github.com/bazelbuild/bazel/blob/master/site/docs/completion.md)
 to install it locally.
 
+### Publishing and running images on a local instance
+
+You can test your images at runtime if you have a local instance of Airy Core
+running on Minikube.
+
+#### Publish image to minikube's registry
+
+In order for the Airy Core cluster to have access to an image, you need to
+publish the image to Minikube's (built-in) docker registry. Do this by pointing
+your shell's docker environment to the one in minikube:
+
+```sh
+eval $(minikube -p airy-core docker-env)
+```
+
+Next, create an image with bazel, which will automatically load the image into
+Minikube's registry:
+
+```sh
+bazel run //backend/api/communication:image
+```
+
+You can verify this action with `docker images` and you can restore the shell
+environment to point to your local docker environment with
+`eval $(minikube -p airy-core docker-env -u)`.
+
+#### Run image on Airy Core
+
+Next, you will want to be able to run this image in the Airy Core cluster.
+For this you need to:
+
+```sh
+kubectl edit deployment [DEPLOYMENT_NAME]
+```
+
+And you need to update the following key-value pairs to point to your local
+image:
+
+```sh
+image: bazel/backend/api/communication:image
+imagePullPolicy: IfNotPresent
+```
+
+Once these changed are saved, the image will be up and running in your local
+cluster.
+
 ## Naming conventions
 
 In order to organize our releases in the best possible way, we follow a few

--- a/docs/docs/guides/contributing.md
+++ b/docs/docs/guides/contributing.md
@@ -113,13 +113,13 @@ to install it locally.
 
 ### Publishing and running images locally
 
-You can test your images locally at runtime if you have a local instance of Airy 
+You can test your images locally at runtime if you have a local instance of Airy
 Core running in Minikube.
 
 #### Publish image to minikube's registry
 
 In order for the Airy Core cluster to have access to a newly built image, you need
-to publish the image to Minikube's (built-in) docker registry. Do this by pointing 
+to publish the image to Minikube's (built-in) docker registry. Do this by pointing
 your shell's docker environment to the docker instance in minikube:
 
 ```sh
@@ -139,7 +139,7 @@ environment to point to your local docker instance with
 
 #### Run image on Airy Core
 
-Next, you will want to run this image in the Airy Core cluster. For this example 
+Next, you will want to run this image in the Airy Core cluster. For this example
 that means you need to:
 
 ```sh

--- a/docs/docs/guides/contributing.md
+++ b/docs/docs/guides/contributing.md
@@ -111,51 +111,42 @@ Bazel also offers a friendly and powerful autocompletion, please refer to [this
 document](https://github.com/bazelbuild/bazel/blob/master/site/docs/completion.md)
 to install it locally.
 
-### Publishing and running images on a local instance
+### Publishing and running images locally
 
-You can test your images at runtime if you have a local instance of Airy Core
-running on Minikube.
+You can test your images locally at runtime if you have a local instance of Airy 
+Core running in Minikube.
 
 #### Publish image to minikube's registry
 
-In order for the Airy Core cluster to have access to an image, you need to
-publish the image to Minikube's (built-in) docker registry. Do this by pointing
-your shell's docker environment to the one in minikube:
+In order for the Airy Core cluster to have access to a newly built image, you need
+to publish the image to Minikube's (built-in) docker registry. Do this by pointing 
+your shell's docker environment to the docker instance in minikube:
 
 ```sh
 eval $(minikube -p airy-core docker-env)
 ```
 
 Next, create an image with bazel, which will automatically load the image into
-Minikube's registry:
+Minikube's registry. For example:
 
 ```sh
 bazel run //backend/api/communication:image
 ```
 
 You can verify this action with `docker images` and you can restore the shell
-environment to point to your local docker environment with
+environment to point to your local docker instance with
 `eval $(minikube -p airy-core docker-env -u)`.
 
 #### Run image on Airy Core
 
-Next, you will want to be able to run this image in the Airy Core cluster.
-For this you need to:
+Next, you will want to run this image in the Airy Core cluster. For this example 
+that means you need to:
 
 ```sh
-kubectl edit deployment [DEPLOYMENT_NAME]
+kubectl patch deployment api-communication -p '{"spec":{"template":{"spec":{"containers":[{"name":"app","image":"bazel/backend/api/communication:image","imagePullPolicy":"Never"}]}}}}'
 ```
 
-And you need to update the following key-value pairs to point to your local
-image:
-
-```sh
-image: bazel/backend/api/communication:image
-imagePullPolicy: IfNotPresent
-```
-
-Once these changed are saved, the image will be up and running in your local
-cluster.
+Once this is done, the image will be up and running in your local cluster.
 
 ## Naming conventions
 


### PR DESCRIPTION
Resolves #1246.

Notes:
- It is probably a good idea to add a new bazel rule that will publish local images with the tag `:latest` (instead of `:image`), otherwise minikube will not refresh the running image when you overwrite it again.
- @ljupcovangelski said: We should add a change to the helm charts, because this patch can be overwritten if somebody does `airy upgrade`. (Perhaps also add a flag to `airy upgrade` in case this is desirable behaviour?)