### PR TITLE
[#2663] Pull busybox from Github packages

### DIFF
--- a/infrastructure/helm-chart/charts/components/charts/api/charts/api-communication/templates/communication/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/api/charts/api-communication/templates/communication/deployment.yaml
@@ -61,7 +61,7 @@ spec:
 {{ toYaml .Values.communication.resources | indent 10 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:

--- a/infrastructure/helm-chart/charts/components/charts/api/charts/api-communication/templates/websocket/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/api/charts/api-communication/templates/websocket/deployment.yaml
@@ -61,7 +61,7 @@ spec:
 {{ toYaml .Values.websocket.resources | indent 10 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:

--- a/infrastructure/helm-chart/charts/components/charts/integration/charts/source-api/templates/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/integration/charts/source-api/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:

--- a/infrastructure/helm-chart/charts/components/charts/integration/charts/webhook/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/integration/charts/webhook/templates/deployments.yaml
@@ -71,7 +71,7 @@ spec:
 {{ toYaml .Values.consumer.resources | indent 10 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-service.sh"]
         env:
@@ -168,7 +168,7 @@ spec:
 {{ toYaml .Values.publisher.resources | indent 10 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:

--- a/infrastructure/helm-chart/charts/components/charts/media/charts/resolver/templates/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/media/charts/resolver/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/templates/backend/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/templates/backend/deployment.yaml
@@ -71,7 +71,7 @@ spec:
 {{ toYaml .Values.backend.resources | indent 10 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/templates/frontend/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/templates/frontend/deployment.yaml
@@ -48,7 +48,7 @@ spec:
 {{ toYaml .Values.frontend.resources | indent 10 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-service.sh"]
         env:

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/facebook/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/facebook/templates/deployments.yaml
@@ -76,7 +76,7 @@ spec:
 {{ toYaml .Values.connector.resources | indent 12 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:
@@ -161,7 +161,7 @@ spec:
 {{ toYaml .Values.eventsRouter.resources | indent 10 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/google/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/google/templates/deployments.yaml
@@ -71,7 +71,7 @@ spec:
 {{ toYaml .Values.connector.resources | indent 12 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:
@@ -159,7 +159,7 @@ spec:
 {{ toYaml .Values.eventsRouter.resources | indent 10 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/twilio/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/twilio/templates/deployments.yaml
@@ -71,7 +71,7 @@ spec:
 {{ toYaml .Values.connector.resources | indent 12 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:
@@ -161,7 +161,7 @@ spec:
 {{ toYaml .Values.eventsRouter.resources | indent 10 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/viber/templates/deployments.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/viber/templates/deployments.yaml
@@ -66,7 +66,7 @@ spec:
 {{ toYaml .Values.connector.resources | indent 12 }}
       initContainers:
         - name: wait
-          image: busybox
+          image: "{{ .Values.global.busyboxImage }}"
           imagePullPolicy: IfNotPresent
           command: [ "/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh" ]
           env:
@@ -156,7 +156,7 @@ spec:
 {{ toYaml .Values.eventsRouter.resources | indent 12 }}
       initContainers:
         - name: wait
-          image: busybox
+          image: "{{ .Values.global.busyboxImage }}"
           imagePullPolicy: IfNotPresent
           command: [ "/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh" ]
           env:

--- a/infrastructure/helm-chart/charts/components/templates/api/admin/deployment.yaml
+++ b/infrastructure/helm-chart/charts/components/templates/api/admin/deployment.yaml
@@ -77,7 +77,7 @@ spec:
 {{ toYaml .Values.api.admin.resources | indent 10 }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:

--- a/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/kafka/templates/statefulset.yaml
+++ b/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/kafka/templates/statefulset.yaml
@@ -108,7 +108,7 @@ spec:
       {{- end }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-service-url.sh"]
         env:
@@ -118,7 +118,7 @@ spec:
         - name: kafka-helper-scripts
           mountPath: /opt/provisioning
       - name: fix-permissions
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command:
           - sh

--- a/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/schema-registry/templates/deployment.yaml
+++ b/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/schema-registry/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
             value: {{ .Values.kafka.bootstrapServers }}
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:

--- a/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/zookeeper/templates/statefulset.yaml
+++ b/infrastructure/helm-chart/charts/prerequisites/charts/kafka/charts/zookeeper/templates/statefulset.yaml
@@ -47,7 +47,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       initContainers:
       - name: fix-permissions
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command:
           - sh

--- a/infrastructure/helm-chart/templates/provisioning/job-kafka.yaml
+++ b/infrastructure/helm-chart/templates/provisioning/job-kafka.yaml
@@ -31,7 +31,7 @@ spec:
           mountPath: /opt/provisioning
       initContainers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-minimum-kafkas.sh"]
         env:

--- a/infrastructure/helm-chart/templates/provisioning/job-wait.yaml
+++ b/infrastructure/helm-chart/templates/provisioning/job-wait.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-service-url.sh"]
         env:
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
       - name: wait
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-service-url.sh"]
         env:

--- a/infrastructure/helm-chart/templates/upgrading/0.29.0.yaml
+++ b/infrastructure/helm-chart/templates/upgrading/0.29.0.yaml
@@ -126,7 +126,7 @@ spec:
     spec:
       initContainers:
       - name: wait-api-admin
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-service.sh"]
         env:
@@ -269,7 +269,7 @@ spec:
     spec:
       initContainers:
       - name: wait-api-admin
-        image: busybox
+        image: "{{ .Values.global.busyboxImage }}"
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "/opt/provisioning/wait-for-service.sh"]
         env:

--- a/infrastructure/helm-chart/values.yaml
+++ b/infrastructure/helm-chart/values.yaml
@@ -1,5 +1,6 @@
 global:
   containerRegistry: ghcr.io/airyhq
+  busyboxImage: ghcr.io/airyhq/infrastructure/busybox:latest
 security:
   systemToken: ""
   allowedOrigins: "*"

--- a/infrastructure/images/busybox/Dockerfile
+++ b/infrastructure/images/busybox/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+
+LABEL maintainer "https://github.com/airyhq"

--- a/infrastructure/images/busybox/Makefile
+++ b/infrastructure/images/busybox/Makefile
@@ -1,0 +1,6 @@
+build:
+	docker build -t busybox .
+
+release: build
+	docker tag busybox ghcr.io/airyhq/infrastructure/busybox
+	docker push ghcr.io/airyhq/infrastructure/busybox


### PR DESCRIPTION
- Push our own busybox image.
- Set it as default in the helm charts.
- Make it optional so that people can overwrite with `--set global.busyboxImage`.

Fixes #2663.