### PR TITLE
[#1497] media resolver crashes on bad configuration

### DIFF
--- a/backend/media/src/main/java/co/airy/core/media/MediaController.java
+++ b/backend/media/src/main/java/co/airy/core/media/MediaController.java
@@ -9,8 +9,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.slf4j.Logger;
-import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,7 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.InputStream;
 
 @RestController
-public class MediaController implements HealthIndicator {
+public class MediaController {
     private static final Logger log = AiryLoggerFactory.getLogger(MediaController.class);
     private final MediaUpload mediaUpload;
 
@@ -49,15 +47,6 @@ public class MediaController implements HealthIndicator {
             log.error("Media upload failed:", e);
             return ResponseEntity.badRequest().body(new RequestErrorResponsePayload(String.format("Media Upload failed with error: %s", e.getMessage())));
         }
-    }
-
-    @Override
-    public Health health() {
-        if (mediaUpload.isConnectionStatus()) {
-            return Health.up().build();
-        }
-        log.error("s3 connection status is not healthy check credentials");
-        return Health.down().build();
     }
 }
 

--- a/backend/media/src/main/java/co/airy/core/media/MediaController.java
+++ b/backend/media/src/main/java/co/airy/core/media/MediaController.java
@@ -53,7 +53,11 @@ public class MediaController implements HealthIndicator {
 
     @Override
     public Health health() {
-        return Health.up().build();
+        if (mediaUpload.isConnectionStatus()) {
+            return Health.up().build();
+        }
+        log.error("s3 connection status is not healthy check credentials");
+        return Health.down().build();
     }
 }
 

--- a/backend/media/src/main/java/co/airy/core/media/services/MediaUpload.java
+++ b/backend/media/src/main/java/co/airy/core/media/services/MediaUpload.java
@@ -43,7 +43,7 @@ public class MediaUpload implements HealthIndicator {
         this.path = appendSlash(path);
         this.host = new URL(String.format("https://%s.s3.amazonaws.com/", bucket));
 
-        // Check if the connection is healthy
+        // Check if the connection is healthy. This is only done during the construction face
         checkConnectionStatus();
     }
 
@@ -84,10 +84,10 @@ public class MediaUpload implements HealthIndicator {
                 connectionStatus = true;
             }
         } catch (SdkClientException e) {
-            log.error("AWS SDK extension", e);
+            log.error("AWS SDK exception", e);
 
         } catch (Exception e) {
-            log.error("unexpected extension", e);
+            log.error("unexpected exception", e);
         }
     }
 

--- a/backend/media/src/main/java/co/airy/core/media/services/MediaUpload.java
+++ b/backend/media/src/main/java/co/airy/core/media/services/MediaUpload.java
@@ -10,6 +10,8 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.Getter;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
@@ -23,7 +25,7 @@ import java.util.List;
 
 @Service
 @EnableRetry
-public class MediaUpload {
+public class MediaUpload implements HealthIndicator {
     private static final Logger log = AiryLoggerFactory.getLogger(MediaUpload.class);
     private final AmazonS3 amazonS3Client;
     private final String bucket;
@@ -87,5 +89,14 @@ public class MediaUpload {
         } catch (Exception e) {
             log.error("unexpected extension", e);
         }
+    }
+
+    @Override
+    public Health health() {
+        if (connectionStatus) {
+            return Health.up().build();
+        }
+        log.error("s3 connection status is not healthy check credentials");
+        return Health.down().build();
     }
 }

--- a/backend/media/src/test/java/co/airy/core/media/services/MediaUploadTest.java
+++ b/backend/media/src/test/java/co/airy/core/media/services/MediaUploadTest.java
@@ -26,7 +26,7 @@ public class MediaUploadTest {
     private AmazonS3 amazonS3Client;
 
     @Test
-    void connectionStatusOK() throws Exception {
+    void connectionStatusOk() throws Exception {
         final List<Bucket> emptyList = Collections.emptyList();
         doReturn(emptyList).when(amazonS3Client).listBuckets();
 
@@ -35,7 +35,7 @@ public class MediaUploadTest {
     }
 
     @Test
-    void connectionStatusNotOK() throws Exception {
+    void connectionStatusNotOk() throws Exception {
         doReturn(null).when(amazonS3Client).listBuckets();
 
         final MediaUpload m = new MediaUpload(amazonS3Client, "my-bucket", "my/path");

--- a/backend/media/src/test/java/co/airy/core/media/services/MediaUploadTest.java
+++ b/backend/media/src/test/java/co/airy/core/media/services/MediaUploadTest.java
@@ -1,0 +1,52 @@
+package co.airy.core.media.services;
+
+
+import co.airy.core.media.services.MediaUpload;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.Bucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+@AutoConfigureMockMvc
+@ExtendWith(SpringExtension.class)
+public class MediaUploadTest {
+    @MockBean
+    private AmazonS3 amazonS3Client;
+
+    @Test
+    void connectionStatusOK() throws Exception {
+        final List<Bucket> emptyList = Collections.emptyList();
+        doReturn(emptyList).when(amazonS3Client).listBuckets();
+
+        final MediaUpload m = new MediaUpload(amazonS3Client, "my-bucket", "my/path");
+        assertThat(m.isConnectionStatus(), equalTo(true));
+    }
+
+    @Test
+    void connectionStatusNotOK() throws Exception {
+        doReturn(null).when(amazonS3Client).listBuckets();
+
+        final MediaUpload m = new MediaUpload(amazonS3Client, "my-bucket", "my/path");
+        assertThat(m.isConnectionStatus(), equalTo(false));
+    }
+
+    @Test
+    void connectionStatusException() throws Exception {
+        doThrow(SdkClientException.class).when(amazonS3Client).listBuckets();
+
+        final MediaUpload m = new MediaUpload(amazonS3Client, "my-bucket", "my/path");
+        assertThat(m.isConnectionStatus(), equalTo(false));
+    }
+}


### PR DESCRIPTION
closes #1497 

Test if the connection is active and health on startup. if not sets the microservice as unhealthy (down)