### PR TITLE
[#2886] Overwrite minikube driver

### DIFF
--- a/cli/pkg/providers/minikube/minikube.go
+++ b/cli/pkg/providers/minikube/minikube.go
@@ -49,7 +49,7 @@ func (p *provider) Provision(providerConfig map[string]string, dir workspace.Con
 		return kube.KubeCtx{}, err
 	}
 
-	if err := p.startCluster(); err != nil {
+	if err := p.startCluster(providerConfig); err != nil {
 		return kube.KubeCtx{}, err
 	}
 
@@ -68,8 +68,13 @@ func checkInstallation() error {
 	return err
 }
 
-func (p *provider) startCluster() error {
-	args := []string{"start", "--driver=virtualbox", "--cpus=4", "--memory=7168", "--extra-config=apiserver.service-node-port-range=1-65535", "--driver=virtualbox"}
+func (p *provider) startCluster(providerConfig map[string]string) error {
+	minikubeDriver := providerConfig["driver"]
+	if minikubeDriver == "" {
+		minikubeDriver = "docker"
+	}
+	driverArg := "--driver=" + minikubeDriver
+	args := []string{"start", "--cpus=4", "--memory=7168", "--extra-config=apiserver.service-node-port-range=1-65535", driverArg}
 	// Prevent minikube download progress bar from polluting the output
 	_, err := runGetOutput(append(args, "--download-only")...)
 	if err != nil {

--- a/docs/docs/getting-started/installation/helm.md
+++ b/docs/docs/getting-started/installation/helm.md
@@ -106,7 +106,7 @@ For more information refer to the [official DigitalOcean Guide](https://docs.dig
 `Airy Core` can be created on Minikube with predefined settings, using the [Airy CLI](/cli/introduction). However, if you want to create your custom Minikube instance, for example with custom settings for CPU and RAM, you can also do that with the [Minikube](https://minikube.sigs.k8s.io/docs/start/) utility:
 
 ```sh
-minikube -p airy start --driver=virtualbox --cpus=4 --memory=7168 --extra-config=apiserver.service-nodeport-range=1-65535
+minikube -p airy start --driver=docker --cpus=4 --memory=7168 --extra-config=apiserver.service-nodeport-range=1-65535
 ```
 
 The `apiserver.service-nodeport-range` settings is needed if you want to use port 80 on the Minikube VM as the NodePort for the ingress controller service.

--- a/docs/docs/getting-started/installation/minikube.md
+++ b/docs/docs/getting-started/installation/minikube.md
@@ -18,11 +18,16 @@ your local machine using [minikube](https://minikube.sigs.k8s.io/).
 
 First install minikube using [their documentation](https://kubernetes.io/de/docs/tasks/tools/install-minikube/). Minikube version v1.19.0 or higher is required.
 
-Next you also need to install the [Airy CLI](cli/introduction.md). Now you can run this command, which will create a new
-minikube cluster on your system and install Airy core on it:
+Next you also need to install the [Airy CLI](cli/introduction.md). Now you can run this command, which will create a new minikube cluster on your system and install Airy core on it:
 
 ```bash
 airy create --provider=minikube my-airy
+```
+
+The minikube provider uses the `docker` driver by default. You can overwrite this with the `--provider-config` option, for example:
+
+```
+airy create --provider=minikube --provider-config driver=virtualbox my-airy
 ```
 
 This will execute the following actions:


### PR DESCRIPTION
Reverting to the `docker` driver as default for Minikube. One can now overwrite the Minikube driver by running:

```
airy create --provider minikube --provider-config driver=virtualbox
```

Resolves #2886 