### PR TITLE
[#3178] Fix scald-down logic for components

### DIFF
--- a/infrastructure/controller/pkg/configmap-controller/update.go
+++ b/infrastructure/controller/pkg/configmap-controller/update.go
@@ -22,14 +22,17 @@ func (r ResourceUpdatedHandler) Handle(ctx Context) error {
 	}
 
 	for _, deployment := range deployments {
-		if r.ConfigMap.Labels["core.airy.co/component"] == r.ConfigMap.Name {
-			if r.ConfigMap.Annotations["core.airy.co/enabled"] == "true" {
-				klog.Infof("Scheduling reload for deployment: %s", deployment.Name)
-				//TODO: Hanlde variable number of replicas
-				deployment.Spec.Replicas = util.Int32Ptr(1)
-			} else {
-				klog.Infof("Scheduling disable for deployment: %s", deployment.Name)
-				deployment.Spec.Replicas = util.Int32Ptr(0)
+		if r.ConfigMap.Labels != nil && r.ConfigMap.Annotations != nil {
+			if r.ConfigMap.Labels["core.airy.co/component"] == r.ConfigMap.Name {
+				if r.ConfigMap.Annotations["core.airy.co/enabled"] == "true" {
+					klog.Infof("Scheduling reload for deployment: %s", deployment.Name)
+					//TODO: Hanlde variable number of replicas
+					deployment.Spec.Replicas = util.Int32Ptr(1)
+				} else {
+					klog.Infof("Scheduling disable for deployment: %s", deployment.Name)
+					deployment.Spec.Replicas = util.Int32Ptr(0)
+				}
+
 			}
 
 		}

--- a/infrastructure/controller/pkg/configmap-controller/update.go
+++ b/infrastructure/controller/pkg/configmap-controller/update.go
@@ -22,13 +22,16 @@ func (r ResourceUpdatedHandler) Handle(ctx Context) error {
 	}
 
 	for _, deployment := range deployments {
-		if r.ConfigMap.Labels != nil && r.ConfigMap.Labels["core.airy.co/component"] == r.ConfigMap.Name && r.ConfigMap.Annotations != nil && r.ConfigMap.Annotations["core.airy.co/enabled"] == "true" {
-			klog.Infof("Scheduling reload for deployment: %s", deployment.Name)
-			//TODO: Hanlde variable number of replicas
-			deployment.Spec.Replicas = util.Int32Ptr(1)
-		} else {
-			klog.Infof("Scheduling disable for deployment: %s", deployment.Name)
-			deployment.Spec.Replicas = util.Int32Ptr(0)
+		if r.ConfigMap.Labels["core.airy.co/component"] == r.ConfigMap.Name {
+			if r.ConfigMap.Annotations["core.airy.co/enabled"] == "true" {
+				klog.Infof("Scheduling reload for deployment: %s", deployment.Name)
+				//TODO: Hanlde variable number of replicas
+				deployment.Spec.Replicas = util.Int32Ptr(1)
+			} else {
+				klog.Infof("Scheduling disable for deployment: %s", deployment.Name)
+				deployment.Spec.Replicas = util.Int32Ptr(0)
+			}
+
 		}
 		if err := handler.ReloadDeployment(deployment, ctx.ClientSet); err != nil {
 			klog.Errorf("Reloading deployment failed: %v", err)


### PR DESCRIPTION
Some of the deployments that should be running (`api-admin` and `sources-chat-plugin`) are scaled down when creating Airy.

Steps to reproduce the bug:
- Run `airy create --provider minikube` (core-config ConfigMap is updated at the end, so all affected deployments are scaled down)
- Restart the airy-controller pod (everything is back to normal)
- Modify the `core-config` ConfigMap - then `api-admin` and `sources-chat-plugin` are scaled down.

Explanation: Whenever a ConfigMap changes - we need to reload the deployment, regardless of whether that ConfigMap defines the component or not. We should scale the deployment down to 0 on behalf of the `core.airy.co/enabled` label, only if the ConfigMap defines the component (ConfigMap.Labels["core.airy.co/component"] == ConfigMap.Name)