### PR TITLE
[#3208] Initial setup for helm chart per component

### DIFF
--- a/docs/docs/api/endpoints/components.md
+++ b/docs/docs/api/endpoints/components.md
@@ -112,3 +112,84 @@ The list of the deleted components is returned.
   }
 }
 ```
+
+## List
+
+List all the components, both installed and not installed.
+
+`POST /components.list`
+
+**Sample request**
+
+```json
+{
+  "repository": "airy-core" // optional
+}
+```
+
+**Sample response**
+
+```json5
+{
+  "components": [
+    {
+      "name": "sources-facebook",
+      "repository": "airy-core",
+      "installed": true
+    },
+    {
+      "name": "sources-google",
+      "repository": "airy-core",
+      "installed": false
+    }
+  ]
+}
+```
+
+## Install
+
+Install a new component.
+
+`POST /components.install`
+
+**Sample request**
+
+```json
+{
+  "name": "sources-chat-plugin"
+}
+```
+
+**Sample response**
+
+The response includes the name of the component that was installed with an indication of the process was completed successfully (true) or not (false).
+
+```json5
+{
+  "sources-chat-plugin": true
+}
+```
+
+## Uninstall
+
+Install an existing component.
+
+`POST /components.uninstall`
+
+**Sample request**
+
+```json
+{
+  "name": "sources-chat-plugin"
+}
+```
+
+**Sample response**
+
+The response includes the name of the component that was uninstalled with an indication of the process was completed successfully (true) or not (false).
+
+```json5
+{
+  "sources-chat-plugin": true
+}
+```

--- a/docs/docs/api/endpoints/repositories.md
+++ b/docs/docs/api/endpoints/repositories.md
@@ -1,0 +1,39 @@
+---
+title: Repositories
+sidebar_label: Repositories
+---
+
+The `repositories.*` API is about controlling the repositories from where the individual components are installed.
+
+## List
+
+Retrieve a list of repositories.
+
+`POST /repositories.list`
+
+The list of the currently configured components is returned.
+
+**Sample response**
+
+```json5
+{
+  "repositories": [
+    {
+      "name": "airy-core",
+      "url": "https://github.com/airyhq/airy/tree/develop/infrastructure/helm-chart/charts/components/charts"
+    },
+    {
+      "name": "airy-enterprise",
+      "url": "enterprise-url"
+    },
+    {
+      "name": "airy-tools",
+      "url": "https://github.com/airyhq/airy/tree/develop/infrastructure/helm-chart/charts/tools/charts"
+    },
+    {
+      "name": "my-custom-airy-repo",
+      "url": "my-custom-url"
+    }
+  ]
+}
+```

--- a/docs/docs/concepts/architecture.md
+++ b/docs/docs/concepts/architecture.md
@@ -5,7 +5,7 @@ sidebar_label: Architecture
 
 ## Overview
 
-Airy Core is a messaging platform that contains a backend and frontend system.
+Airy Core is a conversational platform that contains a backend and frontend system.
 
 The `backend` system is a streaming platform. Its role is to:
 
@@ -15,11 +15,63 @@ The `backend` system is a streaming platform. Its role is to:
 - Expose conversational events via a [webhook](/api/webhook) integration.
 - Manage authentication and authorization features.
 
-The `frontend` system contains a demo application and the JavaScript integration
+The `frontend` system contains Inbox and Control Center web applications and the JavaScript integration
 of the [Chat Plugin](sources/chatplugin/overview.md).
 
-Having that in mind, these are the docker containers – or the `Airy Components` –
-which run as part of Airy Core:
+All of these functionalities are packaged in entities called `Airy Components`. Components are part of a `repository`. By default, the `airy-core` repository is added to an `Airy Core` installation. The conversational platform can further be extended with additional repositories and third party components.
+
+The `airy-core` repository is comprised of the following `Airy Components`:
+
+## Apps
+
+An App is a component or a collection of components which are interconnected and can be used to build any kind of application inside the Airy system.
+
+## Components
+
+A Component is a single unit which is used to build an App alone or together with other Components. There are different types of Components:
+
+- `connector` - a connector is a component which is used to ingest events from and to a different source.
+- `ui` - a UI component is a component which is used to display the events in a user interface.
+- `api` - an API component is a component which is used to expose the events to a third party.
+
+### Connectors
+
+The `connectors` are following a specific naming pattern:
+
+- sources-`CONNECTOR_NAME` - Components which send and receive events to external platforms or systems. Example: `sources-facebook`, `sources-google`, `sources-twilio`.
+
+### API
+
+- api-admin - Backend services for administration of messaging sources and destinations
+- api-communication - Backend services which expose conversations and messages
+- api-websocket - Backend services which streams messages and more via websocket [[docs](/api/websocket.md)]
+
+### Webhook
+
+- webhook-publisher - Processes conversational data and write in Redis the events
+  to be exposed to external parties
+- webhook-consumer - Reads from Redis and send events to external webhooks
+
+### Frontend
+
+- frontend-inbox - Web application for viewing messages
+- frontend-chat-plugin - Web chat plugin
+
+## Pods
+
+Since Airy is built on Kubernetes pods are the smallest deployable unit and therefore are used to compose components.
+A Component can have multiple Services / Pods.
+
+## Airy Controller
+
+Airy Core ships with a Kubernetes controller, which is responsible for starting
+and reloading the appropriate `Airy Components` based on the provided configuration. The controller is a deployment named `airy-controller`.
+
+## Airy CLI
+
+Every release features a command line binary, used to configure and fetch status
+information from your Airy Core instance. This tool is referred to as the [Airy
+CLI](/cli/introduction.md) throughout the documentation.
 
 ## Sensitive data
 
@@ -34,47 +86,3 @@ All the credentials, keys and secrets which the user can overwrite can be config
 - `security` ConfigMap - holding the necessary security parameters.
 - `{component-type}-{component}` ConfigMap - holding the configuration for individual sources and components
 - `airy-config-map` ConfigMap - storing a copy of the `airy.yaml` config file, inside the Kubernetes cluster.
-
-## Apps
-
-An App is a component or a collection of components which are interconnected and can be used to build any kind of application inside the Airy system.
-
-## Components
-
-A Component is a single unit which is used to build an App alone or together with other Components. There are different types of Components:
-
-- `connector` - a connector is a component which is used to ingest events from and to a different source.
-- `ui` - a UI component is a component which is used to display the events in a user interface.
-- `api` - an API component is a component which is used to expose the events to a third party.
-
-## Pods
-
-Since Airy is built on Kubernetes pods are the smallest deployable unit and therefore are used to compose components.
-A Component can have multiple Services / Pods.
-
-## API
-
-- api-admin - Backend services for administration of messaging sources and destinations
-- api-communication - Backend services which expose conversations and messages
-
-## Webhook
-
-- webhook-publisher - Processes conversational data and write in Redis the events
-  to be exposed to external parties
-- webhook-consumer - Reads from Redis and send events to external webhooks
-
-## Frontend
-
-- frontend-ui - Web application for viewing messages
-- frontend-chat-plugin - Web chat plugin
-
-## Airy Controller
-
-Airy Core ships with a Kubernetes controller, which is responsible for starting
-and reloading the appropriate `Airy Components` based on the provided configuration. The controller is a deployment named `airy-controller`.
-
-## Airy CLI
-
-Every release features a command line binary, used to configure and fetch status
-information from your Airy Core instance. This tool is referred to as the [Airy
-CLI](/cli/introduction.md) throughout the documentation.

--- a/docs/docs/getting-started/components.md
+++ b/docs/docs/getting-started/components.md
@@ -22,6 +22,8 @@ Airy Core comes with all the components you need for a fully-featured conversati
 
 <Image lightModePath="img/getting-started/components-light.png" darkModePath="img/getting-started/components-dark.png"/>
 
+## Component types
+
 Airy Core contains the following core components:
 
 <ButtonBoxList>
@@ -68,3 +70,9 @@ Airy Core contains the following core components:
     link='/integrations/rasa-assistant'
 />
 </ButtonBoxList>
+
+## Installation
+
+For installation purposes Airy Core is packaged in a Helm chart which creates all the necessary Kubernetes resources. However, every component is an independent entity and can be installed or uninstalled separately. Every component is packaged in its own independent Helm chart and belongs to a `repository`. By default, the `airy-core` repository is added with the components that can be found under `infrastructure/helm-chart/charts/components/charts`.
+
+Some components are installed by default, while others can be added or removed later, depending on the particular use case. Components can be managed through the `Control center` or through the [components](/api/endpoints/components) and [repositories](/api/endpoints/repositories) API endpoints.

--- a/docs/docs/getting-started/installation/introduction.md
+++ b/docs/docs/getting-started/installation/introduction.md
@@ -35,6 +35,10 @@ link='/cli/introduction'
 />
 </ButtonBoxList>
 
+## Install Airy Core
+
+After you have installed your Airy CLI you can choose one of the following supported platforms and use the CLI to deploy `Airy Core`.
+
 <ButtonBoxList>
 <ButtonBox
 icon={<HelmSVG />}
@@ -44,11 +48,6 @@ description='Deploy Airy Core with Helm, on an existing Kubernetes cluster'
 link='/getting-started/installation/helm'
 />
 </ButtonBoxList>
-
-## Install Airy Core
-
-After you have installed your Airy CLI you can choose one of the following supported platforms and use the CLI to deploy `Airy Core`.
-
 <ButtonBoxList>
 <ButtonBox
 icon={<Minikube />}

--- a/infrastructure/helm-chart/Chart.yaml
+++ b/infrastructure/helm-chart/Chart.yaml
@@ -12,4 +12,3 @@ dependencies:
     condition: tools.enabled
   - name: components
     condition: components.enabled
-

--- a/infrastructure/helm-chart/charts/components/charts/sources/Chart.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/Chart.yaml
@@ -3,3 +3,14 @@ appVersion: "1.0"
 description: A Helm chart for the Airy Core official sources
 name: sources
 version: 1.0
+dependencies:
+  - name: chatplugin
+    condition: chatplugin.installed
+  - name: facebook
+    condition: facebook.enabled
+  - name: google
+    condition: google.enabled
+  - name: twilio
+    condition: twilio.enabled
+  - name: viber
+    condition: viber.enabled

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/BUILD
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/BUILD
@@ -1,0 +1,28 @@
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@com_github_airyhq_bazel_tools//helm:helm.bzl", "helm_template_test")
+load("//tools/build:helm.bzl", "helm_push")
+
+filegroup(
+    name = "files",
+    srcs = glob(
+        ["**/*"],
+        exclude = ["BUILD"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "package",
+    srcs = [":files"],
+    extension = "tgz",
+    strip_prefix = "./",
+)
+
+helm_template_test(
+    name = "template",
+    chart = ":package",
+)
+
+helm_push(
+    chart = ":package",
+)

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/Chart.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for the Sources Chatplugin app
-name: chatplugin
-version: 0-develop
+name: sources-chatplugin
+version: 0

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/templates/backend/service.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/templates/backend/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: sources-chatplugin
+  name: "{{ .Values.component }}"
   labels:
     core.airy.co/prometheus: spring
 spec:
@@ -12,4 +12,4 @@ spec:
       protocol: TCP
   type: NodePort
   selector:
-    app: sources-chatplugin
+    app: "{{ .Values.component }}"

--- a/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/values.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/charts/chatplugin/values.yaml
@@ -7,3 +7,8 @@ backend:
 frontend:
   image: frontend/chat-plugin
   resources: {}
+global:
+  ingress:
+    letsencrypt: false
+  containerRegistry: ghcr.io/airyhq
+  busyboxImage: ghcr.io/airyhq/infrastructure/busybox:latest

--- a/infrastructure/helm-chart/charts/components/charts/sources/values.yaml
+++ b/infrastructure/helm-chart/charts/components/charts/sources/values.yaml
@@ -1,0 +1,2 @@
+chatplugin:
+  installed: false

--- a/infrastructure/helm-chart/templates/config/configmap.yaml
+++ b/infrastructure/helm-chart/templates/config/configmap.yaml
@@ -24,3 +24,11 @@ data:
 {{- if .Values.global.apiHost }}
   API_HOST: {{ .Values.global.apiHost }}
 {{- end }}
+  global.yaml: |
+    global:
+      containerRegistry: {{ .Values.global.containerRegistry }}
+      busyboxImage: {{ .Values.global.busyboxImage }}
+      host: {{ .Values.global.host }}
+      apiHost: {{ .Values.global.apiHost }}
+      ingress:
+        letsencrypt: {{ .Values.global.ingress.letsencrypt }}

--- a/infrastructure/helm-chart/templates/controller/configmap.yaml
+++ b/infrastructure/helm-chart/templates/controller/configmap.yaml
@@ -1,0 +1,15 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: repositories
+  namespace: {{ .Values.namespace }}
+data:
+  repositories.json: |
+    {
+      "repositories": [
+        {
+          "name": "airy-core",
+          "url": "https://github.com/airyhq/airy/tree/develop/infrastructure/helm-chart/charts/components/charts"
+        }
+      ]
+    }

--- a/infrastructure/helm-chart/templates/controller/deployment.yaml
+++ b/infrastructure/helm-chart/templates/controller/deployment.yaml
@@ -43,3 +43,11 @@ spec:
             limits:
               cpu: "50m"
               memory: "128Mi"
+          volumeMounts:
+          - name: repositories
+            mountPath: /repositories.json
+            subPath: repositories.json
+      volumes:
+        - name: repositories
+          configMap:
+            name: repositories


### PR DESCRIPTION
- Add docs for repositories
- Add docs for components
- Setup default repository in the airy-controller
- Package one chart to test install/uninstall functionality
- Add docs to Components/Architecture/Glossary documents
- Test deploying the component manually on an existing Airy instance using:
```
helm install {component-name} https://helm.airy.co/charts/{component-name}-{version}.tgz --values airy.yaml
```

Related to #3208 