### PR TITLE
[#3332] Authenticate AWS using profile

### DIFF
--- a/infrastructure/terraform/kubernetes/main.tf
+++ b/infrastructure/terraform/kubernetes/main.tf
@@ -2,10 +2,9 @@ module "eks" {
   source = "../modules/aws_eks"
 
   core_id = "core"
-
-
-  aws_access_key = var.aws_access_key
-  aws_secret_key = var.aws_secret_key
+  region = var.region
+ 
+  aws_profile = var.aws_profile
 
   fargate_profiles = var.fargate_profiles
 

--- a/infrastructure/terraform/kubernetes/variables.tf
+++ b/infrastructure/terraform/kubernetes/variables.tf
@@ -1,10 +1,11 @@
-variable "aws_access_key" {
-  description = "AWS Access Key"
+variable "aws_profile" {
+  description = "The AWS Profile associated with your credentials (default = 'default')"
 }
 
-variable "aws_secret_key" {
-  description = "AWS Secret Key"
+variable "region" {
+  description = "The AWS region in which resources are created"
 }
+
 
 variable "fargate_profiles" {
   type = list(string)

--- a/infrastructure/terraform/kubernetes/variables.tf
+++ b/infrastructure/terraform/kubernetes/variables.tf
@@ -2,7 +2,7 @@ variable "aws_profile" {
   description = "The AWS Profile associated with your credentials (default = 'default')"
 }
 
-variable "region" {
+variable "aws_region" {
   description = "The AWS region in which resources are created"
 }
 

--- a/infrastructure/terraform/modules/aws_eks/main.tf
+++ b/infrastructure/terraform/modules/aws_eks/main.tf
@@ -1,7 +1,6 @@
 provider "aws" {
   region     = var.region
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
+  profile    = var.aws_profile
 }
 
 locals {

--- a/infrastructure/terraform/modules/aws_eks/variables.tf
+++ b/infrastructure/terraform/modules/aws_eks/variables.tf
@@ -1,14 +1,10 @@
 variable "region" {
-  description = "the AWS region in which resources are created, you must set the availability_zones variable as well if you define this value to something other than the default"
+  description = "The AWS region in which resources are created"
   default     = "eu-west-1"
 }
 
-variable "aws_access_key" {
-  description = "AWS Access Key"
-}
-
-variable "aws_secret_key" {
-  description = "AWS Secret Key"
+variable "aws_profile" {
+  description = "The AWS profile associated with your credentials (default = 'default')"
 }
 
 variable "ssh_key" {


### PR DESCRIPTION
Resolves #3332 by authenticating AWS using the profile instead of credentials in the `main.tf` file.