### PR TITLE
[#3333] - Update kubeconfig api version

### DIFF
--- a/infrastructure/terraform/modules/aws_eks/main.tf
+++ b/infrastructure/terraform/modules/aws_eks/main.tf
@@ -57,6 +57,7 @@ module "eks" {
   subnets                = [local.vpc.private_subnets[0], local.vpc.public_subnets[1]]
   fargate_subnets        = [local.vpc.private_subnets[0]]
   kubeconfig_output_path = var.kubeconfig_output_path
+  kubeconfig_api_version = "client.authentication.k8s.io/v1beta1"
   write_kubeconfig       = true
   map_users              = var.kubernetes_users
   tags                   = var.tags


### PR DESCRIPTION
Resolves #3333 using the `kubeconfig_api_version` input parameter in version `17.24` of the `terraform-aws-modules/eks/aws` module in the aws_eks terraform code to set the API to be `v1beta1`