### PR TITLE
[#3359] Add method to check environment pre-install

### DIFF
--- a/cli/pkg/cmd/create/create.go
+++ b/cli/pkg/cmd/create/create.go
@@ -65,9 +65,15 @@ func create(cmd *cobra.Command, args []string) {
 	overrides.Version = version
 	overrides.Namespace = namespace
 	overrides.TrackingDisabled = disableTracking
+	isValidEnv, err := provider.IsEnvironmentValid()
+
+	if !isValidEnv {
+		console.Exit("Please check if the install requirements are set up", err)
+	}
+
 	dir, err := workspace.Create(workspacePath, overrides)
 	if err != nil {
-		console.Exit("could not initialize Airy workspace directory", err)
+		console.Exit("Could not initialize Airy workspace directory", err)
 	}
 	fmt.Println("📁 Initialized Airy workspace directory at", dir.GetPath("."))
 	if initOnly {

--- a/cli/pkg/cmd/create/create.go
+++ b/cli/pkg/cmd/create/create.go
@@ -68,12 +68,12 @@ func create(cmd *cobra.Command, args []string) {
 	isValidEnv, err := provider.IsEnvironmentValid()
 
 	if !isValidEnv {
-		console.Exit("Please check if the install requirements are set up", err)
+		console.Exit("please check if the install requirements are set up", err)
 	}
 
 	dir, err := workspace.Create(workspacePath, overrides)
 	if err != nil {
-		console.Exit("Could not initialize Airy workspace directory", err)
+		console.Exit("could not initialize Airy workspace directory", err)
 	}
 	fmt.Println("📁 Initialized Airy workspace directory at", dir.GetPath("."))
 	if initOnly {

--- a/cli/pkg/providers/aws/aws.go
+++ b/cli/pkg/providers/aws/aws.go
@@ -52,16 +52,15 @@ func (p *provider) GetOverrides() tmpl.Variables {
 	}
 }
 
-func (p *provider) CheckEnvironment() (bool, string) {
+func (p *provider) IsEnvironmentValid() (bool, error) {
 	necessaryBinaries := [2]string{"aws", "terraform"}
 	for _, binary := range necessaryBinaries {
 		_, err := exec.LookPath(binary)
 		if err != nil {
-			errMsg := fmt.Sprintf("Please check %s\nError - %s", binary, err)
-			return false, errMsg
+			return false, err
 		}
 	}
-	return true, ""
+	return true, nil
 }
 
 func (p *provider) PostInstallation(providerConfig map[string]string, namespace string, dir workspace.ConfigDir) error {

--- a/cli/pkg/providers/aws/aws.go
+++ b/cli/pkg/providers/aws/aws.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"os/exec"
 	"strings"
 	"text/template"
 	"time"
@@ -49,6 +50,18 @@ func (p *provider) GetOverrides() tmpl.Variables {
 	return tmpl.Variables{
 		LoadbalancerAnnotations: map[string]string{"service.beta.kubernetes.io/aws-load-balancer-type": "nlb"},
 	}
+}
+
+func (p *provider) CheckEnvironment() (bool, string) {
+	necessaryBinaries := [2]string{"aws", "terraform"}
+	for _, binary := range necessaryBinaries {
+		_, err := exec.LookPath(binary)
+		if err != nil {
+			errMsg := fmt.Sprintf("Please check %s\nError - %s", binary, err)
+			return false, errMsg
+		}
+	}
+	return true, ""
 }
 
 func (p *provider) PostInstallation(providerConfig map[string]string, namespace string, dir workspace.ConfigDir) error {

--- a/cli/pkg/providers/minikube/minikube.go
+++ b/cli/pkg/providers/minikube/minikube.go
@@ -45,8 +45,8 @@ func (p *provider) GetOverrides() template.Variables {
 	}
 }
 
-func (p *provider) CheckEnvironment() (bool, string) {
-	return true, ""
+func (p *provider) IsEnvironmentValid() (bool, error) {
+	return true, nil
 }
 
 func (p *provider) Provision(providerConfig map[string]string, dir workspace.ConfigDir) (kube.KubeCtx, error) {

--- a/cli/pkg/providers/minikube/minikube.go
+++ b/cli/pkg/providers/minikube/minikube.go
@@ -45,6 +45,10 @@ func (p *provider) GetOverrides() template.Variables {
 	}
 }
 
+func (p *provider) CheckEnvironment() (bool, string) {
+	return true, ""
+}
+
 func (p *provider) Provision(providerConfig map[string]string, dir workspace.ConfigDir) (kube.KubeCtx, error) {
 	if err := checkInstallation(); err != nil {
 		return kube.KubeCtx{}, err

--- a/cli/pkg/providers/provider.go
+++ b/cli/pkg/providers/provider.go
@@ -21,6 +21,7 @@ const (
 type Provider interface {
 	Provision(providerConfig map[string]string, dir workspace.ConfigDir) (kube.KubeCtx, error)
 	GetOverrides() template.Variables
+	CheckEnvironment() (bool, string)
 	PostInstallation(providerConfig map[string]string, namespace string, dir workspace.ConfigDir) error
 }
 

--- a/cli/pkg/providers/provider.go
+++ b/cli/pkg/providers/provider.go
@@ -21,7 +21,7 @@ const (
 type Provider interface {
 	Provision(providerConfig map[string]string, dir workspace.ConfigDir) (kube.KubeCtx, error)
 	GetOverrides() template.Variables
-	CheckEnvironment() (bool, string)
+	IsEnvironmentValid() (bool, error)
 	PostInstallation(providerConfig map[string]string, namespace string, dir workspace.ConfigDir) error
 }
 


### PR DESCRIPTION
Resolves #3359 and also adds a new method to the `provider` interface called `IsEnvironmentValid()`. This function allows us to check that the installer's local environment has the necessary binaries and configurations we expect to make the install run. In this case we are checking for `aws` and `terraform` (but not checking their version)