### PR TITLE
[#2757] Use Terraform for Minikube provider

### DIFF
--- a/cli/pkg/cmd/status/BUILD
+++ b/cli/pkg/cmd/status/BUILD
@@ -11,7 +11,6 @@ go_library(
         "//lib/go/httpclient",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_spf13_viper//:viper",
-        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
     ],
 )
 

--- a/cli/pkg/providers/aws/BUILD
+++ b/cli/pkg/providers/aws/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//cli/pkg/kube",
         "//cli/pkg/workspace",
         "//cli/pkg/workspace/template",
+        "//lib/go/tools",
         "@com_github_hashicorp_go_getter//:go-getter",
         "@in_gopkg_segmentio_analytics_go_v3//:analytics-go_v3",
     ],

--- a/cli/pkg/providers/aws/aws.go
+++ b/cli/pkg/providers/aws/aws.go
@@ -2,21 +2,18 @@ package aws
 
 import (
 	"cli/pkg/console"
-	"cli/pkg/kube"
 	"cli/pkg/workspace"
 	tmpl "cli/pkg/workspace/template"
 	"io"
-	"math/rand"
 	"os"
 	"os/exec"
 	"strings"
-	"time"
+
+	"github.com/airyhq/airy/lib/go/tools"
 
 	getter "github.com/hashicorp/go-getter"
 	"gopkg.in/segmentio/analytics-go.v3"
 )
-
-var letters = []rune("abcdefghijklmnopqrstuvwxyz")
 
 type provider struct {
 	w         io.Writer
@@ -68,15 +65,14 @@ type KubeConfig struct {
 	CertificateData string
 }
 
-func (p *provider) Provision(providerConfig map[string]string, dir workspace.ConfigDir) (kube.KubeCtx, error) {
+func (p *provider) Provision(providerConfig map[string]string, dir workspace.ConfigDir) error {
 	installPath := dir.GetPath(".")
-	id := RandString(8)
+	id := tools.RandString(8)
 	p.analytics.Track(analytics.Identify{
 		AnonymousId: id,
 		Traits: analytics.NewTraits().
 			Set("provider", "AWS"),
 	})
-	name := "Airy-" + id
 	cmd := exec.Command("/bin/bash", "install.sh")
 	cmd.Dir = installPath
 	cmd.Stdin = os.Stdin
@@ -87,18 +83,5 @@ func (p *provider) Provision(providerConfig map[string]string, dir workspace.Con
 	if err != nil {
 		console.Exit("Error with Terraform installation", err)
 	}
-	ctx := kube.KubeCtx{
-		KubeConfigPath: "./kube.conf", // change this into a CLI
-		ContextName:    name,
-	}
-	return ctx, nil
-}
-
-func RandString(n int) string {
-	rand.Seed(time.Now().UnixNano())
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
-	}
-	return string(b)
+	return nil
 }

--- a/cli/pkg/providers/minikube/BUILD
+++ b/cli/pkg/providers/minikube/BUILD
@@ -10,8 +10,8 @@ go_library(
         "//cli/pkg/kube",
         "//cli/pkg/workspace",
         "//cli/pkg/workspace/template",
+        "//lib/go/tools",
+        "@com_github_hashicorp_go_getter//:go-getter",
         "@in_gopkg_segmentio_analytics_go_v3//:analytics-go_v3",
-        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
-        "@io_k8s_client_go//util/homedir:go_default_library",
     ],
 )

--- a/cli/pkg/providers/provider.go
+++ b/cli/pkg/providers/provider.go
@@ -2,7 +2,6 @@ package providers
 
 import (
 	"cli/pkg/console"
-	"cli/pkg/kube"
 	"cli/pkg/providers/aws"
 	"cli/pkg/providers/minikube"
 	"cli/pkg/workspace"
@@ -19,7 +18,7 @@ const (
 )
 
 type Provider interface {
-	Provision(providerConfig map[string]string, dir workspace.ConfigDir) (kube.KubeCtx, error)
+	Provision(providerConfig map[string]string, dir workspace.ConfigDir) error
 	GetOverrides() template.Variables
 	CheckEnvironment() error
 	PreInstallation(workspace string) (string, error)

--- a/infrastructure/terraform/install/airy-core/outputs.tf
+++ b/infrastructure/terraform/install/airy-core/outputs.tf
@@ -10,5 +10,5 @@ output "NGROK" {
 
 output "Info" {
   description = "More information"
-  value       = "For more information about the AWS provider visit https://airy.co/docs/core/getting-started/installation/aws"
+  value       = "For more information visit https://airy.co/docs/core/getting-started/installation/introduction"
 }

--- a/infrastructure/terraform/install/airy-core/outputs.tf
+++ b/infrastructure/terraform/install/airy-core/outputs.tf
@@ -1,6 +1,11 @@
 output "API" {
   description = "The URL where the API and the UI can be reached"
-  value       = module.airy_core.loadbalancer
+  value       = module.airy_core.api_host
+}
+
+output "NGROK" {
+  description = "The URL where the API and the UI can be reached"
+  value       = "https://${module.airy_core.unique_id}.tunnel.airy.co"
 }
 
 output "Info" {

--- a/infrastructure/terraform/install/minikube/main.tf
+++ b/infrastructure/terraform/install/minikube/main.tf
@@ -1,0 +1,6 @@
+module "minikube" {
+  #source = "github.com/airyhq/airy.git/infrastructure/terraform/modules/minikube"
+  source = "../../modules/minikube"
+
+  kubeconfig_output_path = "../kube.conf"
+}

--- a/infrastructure/terraform/install/minikube/main.tf
+++ b/infrastructure/terraform/install/minikube/main.tf
@@ -1,6 +1,4 @@
 module "minikube" {
-  #source = "github.com/airyhq/airy.git/infrastructure/terraform/modules/minikube"
-  source = "../../modules/minikube"
-
+  source = "github.com/airyhq/airy.git/infrastructure/terraform/modules/minikube"
   kubeconfig_output_path = "../kube.conf"
 }

--- a/infrastructure/terraform/install/minikube/outputs.tf
+++ b/infrastructure/terraform/install/minikube/outputs.tf
@@ -1,0 +1,3 @@
+output "kubeconfig_path" {
+  value = module.minikube.kubeconfig_path
+}

--- a/infrastructure/terraform/install/minikube/state.tf
+++ b/infrastructure/terraform/install/minikube/state.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "local" {
+    path = "../kubernetes.tfstate"
+  }
+}

--- a/infrastructure/terraform/modules/core/outputs.tf
+++ b/infrastructure/terraform/modules/core/outputs.tf
@@ -3,6 +3,21 @@ output "core_id" {
 }
 
 output "loadbalancer" {
-    description = "The URL for the load balancer of the cluster. Used to access the UI via the browser"
-    value       = data.kubernetes_service.ingress.status.0.load_balancer.0.ingress.0.hostname
+  description = "The URL for the load balancer of the cluster. Used to access the UI via the browser"
+  value       = try(data.kubernetes_service.ingress.status.0.load_balancer.0.ingress.0.hostname,data.kubernetes_config_map.core_config.data.HOST)
+}
+
+output "api_host" {
+  description = "The URL of the API and the UI"
+  value       = try(data.kubernetes_config_map.core_config.data.API_HOST,data.kubernetes_config_map.core_config.data.HOST)
+}
+
+output "version" {
+  description = "The URL of the API and the UI"
+  value       = data.kubernetes_config_map.core_config.data.APP_IMAGE_TAG
+}
+
+output "unique_id" {
+  description = "Unique ID used for the NGrok public tunnel"
+  value       = data.kubernetes_config_map.core_config.data.CORE_ID
 }

--- a/infrastructure/terraform/modules/core/variables.tf
+++ b/infrastructure/terraform/modules/core/variables.tf
@@ -15,10 +15,12 @@ variable "namespace" {
 
 variable "values_yaml" {
   description = "The helm values overrides"
+  type        = string
 }
 
 variable "resources_yaml" {
   description = "Resource requests and limits for the components"
+  default     = ""
 }
 
 variable "prerequisite_properties_yaml" {
@@ -28,12 +30,15 @@ variable "prerequisite_properties_yaml" {
 
 variable "core_version" {
   description = "Version of the Airy Core instance"
-  type        = string
   default     = ""
 }
 
 variable "ingress_controller_enabled" {
   description = "Whether to create the NGinx ingress controller"
-  type        = string
   default     = "true"
+}
+
+variable "timeout" {
+  description = "Timeout for the Helm installation"
+  default     = 600
 }

--- a/infrastructure/terraform/modules/minikube/main.tf
+++ b/infrastructure/terraform/modules/minikube/main.tf
@@ -1,0 +1,19 @@
+resource "null_resource" "minikube" {
+  triggers = {
+    profile         = var.profile
+    driver          = var.driver
+    cpus            = var.cpus
+    memory          = var.memory
+    nodeport        = var.nodeport
+    kubeconfig_output_path = var.kubeconfig_output_path
+  }
+
+  provisioner "local-exec" {
+    command = "KUBECONFIG=${self.triggers.kubeconfig_output_path} minikube -p ${self.triggers.profile} start --driver=${self.triggers.driver} --cpus=${self.triggers.cpus} --memory=${self.triggers.memory} --container-runtime=containerd --ports=${self.triggers.nodeport}:${self.triggers.nodeport} --extra-config=apiserver.service-node-port-range=1-65535"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "minikube -p ${self.triggers.profile} delete"
+  }
+}

--- a/infrastructure/terraform/modules/minikube/outputs.tf
+++ b/infrastructure/terraform/modules/minikube/outputs.tf
@@ -1,0 +1,4 @@
+output "kubeconfig_path" {
+    description = "The location of the KUBECONFIG file that was used"
+    value       = var.kubeconfig_output_path
+}

--- a/infrastructure/terraform/modules/minikube/variables.tf
+++ b/infrastructure/terraform/modules/minikube/variables.tf
@@ -1,0 +1,28 @@
+variable "profile" {
+  description = "The profile to be used for Minikube"
+  default     = "airy-core"
+}
+
+variable "driver" {
+  description = "The driver to be used for Minikube"
+  default     = "docker"
+}
+
+variable "cpus" {
+  description = "Number of CPUs Minikube should use"
+  default     = 3
+}
+
+variable "memory" {
+  description = "Amount of memory Minikube should use"
+  default     = 7168
+}
+
+variable "nodeport" {
+  description = "The port on which the ingress controller, the API and the web UI will be reached"
+  default     = 80
+}
+
+variable "kubeconfig_output_path" {
+  description = "The path where the KUBECONFIG file will be written"
+}

--- a/lib/go/tools/BUILD
+++ b/lib/go/tools/BUILD
@@ -1,0 +1,12 @@
+load("@com_github_airyhq_bazel_tools//lint:buildifier.bzl", "check_pkg")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+# gazelle:prefix github.com/airyhq/airy/lib/go/tools
+
+go_library(
+    name = "tools",
+    srcs = ["tools.go"],
+    importpath = "github.com/airyhq/airy/lib/go/tools",
+    visibility = ["//visibility:public"],
+)
+
+check_pkg(name = "buildifier")

--- a/lib/go/tools/tools.go
+++ b/lib/go/tools/tools.go
@@ -1,0 +1,17 @@
+package tools
+
+import (
+	"math/rand"
+	"time"
+)
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyz")
+
+func RandString(n int) string {
+	rand.Seed(time.Now().UnixNano())
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
Use Terraform for Minikube as well:
- Minikube module
- Write the `install.flags` from the CLi
- Run the `install.sh` script when running `airy create --provider minikube`

Resolves #2754.