### PR TITLE
[#3558] Docs for Contributing and Defining Components 

### DIFF
--- a/docs/docs/getting-started/componentDefinition.mdx
+++ b/docs/docs/getting-started/componentDefinition.mdx
@@ -1,13 +1,1 @@
-A component is a Helm Chart that can be installed on an Airy Cluster in order to extend its functionality.
-
-Components can be characterized by the functionality they enable:
-
-1. UI Components that provide new user interfaces in Airy.
-2. Connector Components that connect one or more third-party services with Airy to exchange data. 
-3. API Components that expose additional endpoints to Airy.
-
-:::note
-
-A Component can provide multiple functions (e.g., Connector & UI or UI & API) but usually has a single primary function. You can find a more detailed description of a specific component in the `description.yaml` file of the component in our [airy-components](https://github.com/airyhq/airy-components) respository.
-
-:::
+A component is a [Helm Chart](https://helm.sh/docs/topics/charts/) (a package of Kubernetes resources) that represents a functional unit in an Airy instance.

--- a/docs/docs/getting-started/componentDefinition.mdx
+++ b/docs/docs/getting-started/componentDefinition.mdx
@@ -1,8 +1,10 @@
-A component is a Helm Chart that is installed on an Airy Cluster, and extends Airy's functionality in up to three ways:
+A component is a Helm Chart that can be installed on an Airy Cluster in order to extend its functionality.
 
-1. UI Components provide new user interfaces in Airy
-2. Connector Components connect one or more third-party services with Airy to exchange data. 
-3. API Components expose additional endpoints to Airy.
+Components can be characterized by the functionality they enable:
+
+1. UI Components that provide new user interfaces in Airy
+2. Connector Components that connect one or more third-party services with Airy to exchange data. 
+3. API Components that expose additional endpoints to Airy.
 
 :::note
 

--- a/docs/docs/getting-started/componentDefinition.mdx
+++ b/docs/docs/getting-started/componentDefinition.mdx
@@ -1,0 +1,11 @@
+A component is a Helm Chart that is installed on an Airy Cluster, and extends Airy's functionality in up to three ways.
+
+1. UI Components provide new user interfaces in Airy
+2. Connector Components connect to one or more third-party services to exchange data with Airy. 
+3. API Components expose additional endpoints to Airy.
+
+:::note
+
+A Component can provide multiple functions (e.g., Connector & UI or UI & API) but usually has a single primary function. You can find a more detailed description of a specific component in the `description.yaml` file of the component in our [airy-components](https://github.com/airyhq/airy-components) respository.
+
+:::

--- a/docs/docs/getting-started/componentDefinition.mdx
+++ b/docs/docs/getting-started/componentDefinition.mdx
@@ -2,7 +2,7 @@ A component is a Helm Chart that can be installed on an Airy Cluster in order to
 
 Components can be characterized by the functionality they enable:
 
-1. UI Components that provide new user interfaces in Airy
+1. UI Components that provide new user interfaces in Airy.
 2. Connector Components that connect one or more third-party services with Airy to exchange data. 
 3. API Components that expose additional endpoints to Airy.
 

--- a/docs/docs/getting-started/componentDefinition.mdx
+++ b/docs/docs/getting-started/componentDefinition.mdx
@@ -1,7 +1,7 @@
-A component is a Helm Chart that is installed on an Airy Cluster, and extends Airy's functionality in up to three ways.
+A component is a Helm Chart that is installed on an Airy Cluster, and extends Airy's functionality in up to three ways:
 
 1. UI Components provide new user interfaces in Airy
-2. Connector Components connect to one or more third-party services to exchange data with Airy. 
+2. Connector Components connect one or more third-party services with Airy to exchange data. 
 3. API Components expose additional endpoints to Airy.
 
 :::note

--- a/docs/docs/getting-started/components.md
+++ b/docs/docs/getting-started/components.md
@@ -22,9 +22,15 @@ Airy Core comes with all the components you need for a fully-featured conversati
 
 <Image lightModePath="img/getting-started/components-light.png" darkModePath="img/getting-started/components-dark.png"/>
 
+## Definition
+
+import ComponentDefinition from '../getting-started/componentDefinition.mdx'
+
+<ComponentDefinition/>
+
 ## Component types
 
-Airy Core contains the following core components:
+Airy Core contains the following components:
 
 <ButtonBoxList>
 <ButtonBox

--- a/docs/docs/getting-started/glossary.md
+++ b/docs/docs/getting-started/glossary.md
@@ -8,7 +8,7 @@ import TLDR from "@site/src/components/TLDR";
 
 <TLDR>
 
-Airy Core allows its [users](#user) to process messaging data from a variety of
+Airy allows its [users](#user) to process messaging data from a variety of
 [sources](#source), which are integrated via [source providers](#provider).
 Users connect sources via [channels](#channel). Once the channel is connected,
 Airy Core ingests source data and transforms them into
@@ -27,6 +27,12 @@ is the right place. Furthermore, it is worth underlining that the Avro data
 model and glossary do not correspond exactly. The former is the exact machine
 representation of the data we store and the latter is a conceptual artifact we
 created to discuss and solve problems.
+
+## Component
+
+import ComponentDefinition from './componentDefinition.mdx'
+
+<ComponentDefinition/>
 
 ## Channel
 

--- a/docs/docs/guides/contributing-components.md
+++ b/docs/docs/guides/contributing-components.md
@@ -3,7 +3,7 @@ title: Contributing Components
 sidebar_label: Contributing Components
 ---
 
-:::warning 
+:::warning
 
 This functionality is under development. With these docs, we aim to elicit feedback from our community (you!) and focus our development efforts. Currently, we do not offer support for 3rd party components, but we are working toward supporting this.
 

--- a/docs/docs/guides/contributing-components.md
+++ b/docs/docs/guides/contributing-components.md
@@ -9,7 +9,9 @@ This functionality is under development. With these docs, we aim to elicit feedb
 
 :::
 
-`Airy Core` is fundamentally a collection of components. When you install `Airy Core`, you install a set of _core_ components which create the minimum infrastructure to install other components and begin using the platform. These core components are:
+`Airy Core` is fundamentally a collection of components. When you [install `Airy Core`](../getting-started/installation/introduction.md), you install a set of _core_ components which create the minimum infrastructure to install other components and begin using the platform. 
+
+These core components are:
 
 1. airy-controller
 2. api-admin
@@ -18,20 +20,20 @@ This functionality is under development. With these docs, we aim to elicit feedb
 5. frontend-inbox
 6. frontend-control-center
 
-Airy's real value comes from the additional components you can install through our marketplace in the Control Center UI of your Airy Instance. This documentation is on the processes we follow to create, update and store our components.
+Airy's real value comes from the additional components you install through our marketplace in the Control Center UI of your Airy Instance. This documentation is on the processes we follow to create, update and store our components.
 
-## Components
+## A Component
 
-Airy is designed to support a plug-and-play architecture. Components can be added like blocks in the cluster. Components can provide four kinds of functionality:
+Airy is designed to support a plug-and-play architecture. Components once installed are be added as pods your cluster. Components can provide four kinds of functionality:
 
 1. Connector - i.e Rasa, DialogFlow - that [DEFINE]
 2. Source - i.e., Facebook, WhatsApp, SMS -
 3. API - i.e
 4. User Interface - i.e
 
-As a technical artifact, a component is a containerized application (we use Docker) packaged using Helm.
+As a technical artifact, a component is a containerized application (we use Docker) that is packaged and installed using Helm.
 
-The Helm charts and details about all components (except "Core" components) are stored in an external repository managed by Airy called [airy-/airy-components](https://github.com/airyhq/airy-/airy-components). Each directory represents a component.
+The Helm charts and details about all components (except "Core" components) are stored in an external repository managed by Airy called [airy-components](https://github.com/airyhq/airy-/airy-components). This repository is made up directories, where each directory represents a component.
 
 ## Component File Structure
 
@@ -44,7 +46,7 @@ Below is a model of the file stucture of a single component inside the `airy-com
 		/helm
 ```
 
-The `helm` directory contains the `values.yaml` file and all other templates/files needed to install the component onto a Kubernetes cluster using `helm`.
+The `helm` directory contains the `values.yaml` file and all other templates/files needed to make up the Helm package. 
 
 The `information.yaml` is the source-of-truth for every component. It includes a description of its functionality, pricing, availability, and version. This file is written by the component maintainer and rendered into the UI of the Control Center.
 

--- a/docs/docs/guides/contributing-components.md
+++ b/docs/docs/guides/contributing-components.md
@@ -22,22 +22,22 @@ These core components are:
 
 Airy's real value comes from the additional components you install through our marketplace in the Control Center UI of your Airy Instance. This documentation is on the processes we follow to create, update and store our components.
 
-## A Component
+## Components
 
-Airy is designed to support a plug-and-play architecture. Components once installed are be added as pods your cluster. Components can provide four kinds of functionality:
+Airy is designed to support a plug-and-play architecture. Components are installed and run as pods in your cluster. Components can provide four kinds of functionality:
 
-1. Connector - i.e Rasa, DialogFlow - that [DEFINE]
-2. Source - i.e., Facebook, WhatsApp, SMS -
+1. Connector - i.e Rasa, DialogFlow
+2. Source - i.e., Facebook, WhatsApp, SMS
 3. API - i.e
 4. User Interface - i.e
 
-As a technical artifact, a component is a containerized application (we use Docker) that is packaged and installed using Helm.
+As a technical artifact, each component is a containerized application that is packaged and can be installed. We use Docker and Helm for this.
 
-The Helm charts and details about all components (except "Core" components) are stored in an external repository managed by Airy called [airy-components](https://github.com/airyhq/airy-/airy-components). This repository is made up directories, where each directory represents a component.
+The Helm package and information on each components (except core components) are stored in an external repository managed by Airy called [airy-components](https://github.com/airyhq/airy-/airy-components). This repository is made up directories where each one contains the component's Helm package and information on it.
 
-## Component File Structure
+## The Component File Structure
 
-Below is a model of the file stucture of a single component inside the `airy-components` repository.
+Below is a model of the file stucture of a single component inside the [`airy-components`](https://github.com/airyhq/airy-/airy-components) repository.
 
 ```
 /airy-components
@@ -46,7 +46,7 @@ Below is a model of the file stucture of a single component inside the `airy-com
 		/helm
 ```
 
-The `helm` directory contains the `values.yaml` file and all other templates/files needed to make up the Helm package.
+The `helm` directory contains all the files that make up the Helm package.
 
 The `information.yaml` is the source-of-truth for every component. It includes a description of its functionality, pricing, availability, and version. This file is written by the component maintainer and rendered into the UI of the Control Center.
 

--- a/docs/docs/guides/contributing-components.md
+++ b/docs/docs/guides/contributing-components.md
@@ -5,11 +5,17 @@ sidebar_label: Contributing Components
 
 :::warning
 
-This functionality is under development. With these docs, we aim to elicit feedback from our community (you!) and focus our development efforts. Currently, we do not offer support for 3rd party components, but we are working toward supporting this.
+This functionality does not yet exist and is under development. With these docs, we aim to elicit feedback from our community (you!) and focus our development efforts. Currently, we do not offer support for 3rd party components, but we are working toward supporting this.
 
 :::
 
-Airy's functions are provided by components ready for _plug and play_. With every [installation of Airy](../getting-started/installation/introduction.md) we bundle a few default components to get started:
+## Components
+
+import ComponentDefinition from '../getting-started/componentDefinition.mdx'
+
+<ComponentDefinition/>
+
+Airy components are ready for _plug and play_. With every [installation of Airy](../getting-started/installation/introduction.md) we bundle a few necessary components to get you started:
 
 1. airy-controller
 2. api-admin
@@ -21,13 +27,7 @@ Airy's functions are provided by components ready for _plug and play_. With ever
 Airy's real value comes from the additional components you install through our catalog in the Control Center UI of your Airy Instance.
 In the following, we will explain how to create, update and store components.
 
-## Components
-
-import ComponentDefinition from '../getting-started/componentDefinition.mdx'
-
-<ComponentDefinition/>
-
-The Helm package and information on each component (except core components) are stored in an external repository managed by Airy called [airy-components](https://github.com/airyhq/airy-/airy-components). This repository is made up of directories where each directory contains a component's Helm package and information.
+The Helm package and information on each component (except core components) are stored in an external repository managed by Airy called [airy-components](https://github.com/airyhq/airy-/airy-components). This repository is made up of directories where each directory contains a component's Helm package its description.
 
 ## The Component File Structure
 
@@ -36,14 +36,14 @@ Below is a model of the file structure of a single component inside the [`airy-c
 ```
 airy-components/
 └── [COMPONENT_NAME]/
-    ├── information.yaml
+    ├── description.yaml
     └── helm/
         └── [HELM CHART]
 ```
 
 The `helm` directory contains all the files that make up the Helm package.
 
-The `information.yaml` is the source-of-truth for every component. It includes a description of its functionality, pricing, availability, and version. This file is written by the component maintainer and rendered into the UI of the Control Center.
+The `description.yaml` is the source-of-truth for every component. It includes a description of its functionality, pricing, availability, and version. This file is written by the component maintainer and rendered into the UI of the Control Center.
 
 :::note
 

--- a/docs/docs/guides/contributing-components.md
+++ b/docs/docs/guides/contributing-components.md
@@ -9,7 +9,7 @@ This functionality is under development. With these docs, we aim to elicit feedb
 
 :::
 
-`Airy Core` is fundamentally a collection of components. When you [install `Airy Core`](../getting-started/installation/introduction.md), you install a set of _core_ components which create the minimum infrastructure to install other components and begin using the platform. 
+`Airy Core` is fundamentally a collection of components. When you [install `Airy Core`](../getting-started/installation/introduction.md), you install a set of _core_ components which create the minimum infrastructure to install other components and begin using the platform.
 
 These core components are:
 
@@ -46,7 +46,7 @@ Below is a model of the file stucture of a single component inside the `airy-com
 		/helm
 ```
 
-The `helm` directory contains the `values.yaml` file and all other templates/files needed to make up the Helm package. 
+The `helm` directory contains the `values.yaml` file and all other templates/files needed to make up the Helm package.
 
 The `information.yaml` is the source-of-truth for every component. It includes a description of its functionality, pricing, availability, and version. This file is written by the component maintainer and rendered into the UI of the Control Center.
 

--- a/docs/docs/guides/contributing-components.md
+++ b/docs/docs/guides/contributing-components.md
@@ -15,7 +15,7 @@ import ComponentDefinition from '../getting-started/componentDefinition.mdx'
 
 <ComponentDefinition/>
 
-Airy components are ready for _plug and play_. With every [installation of Airy](../getting-started/installation/introduction.md) we bundle a few necessary components to get you started:
+With every [installation of Airy](../getting-started/installation/introduction.md) we bundle a default components to get you started:
 
 1. airy-controller
 2. api-admin
@@ -24,7 +24,8 @@ Airy components are ready for _plug and play_. With every [installation of Airy]
 5. frontend-inbox
 6. frontend-control-center
 
-Airy's real value comes from the additional components you install through our catalog in the Control Center UI of your Airy Instance.
+Airy also provides a marketplace of _plug and play_ components that extend the functionality of your Airy instance. You can install them through our catalog in the Control Center UI of your Airy Instance.
+
 In the following, we will explain how to create, update and store components.
 
 The Helm package and information on each component (except core components) are stored in an external repository managed by Airy called [airy-components](https://github.com/airyhq/airy-/airy-components). This repository is made up of directories where each directory contains a component's Helm package its description.

--- a/docs/docs/guides/contributing-components.md
+++ b/docs/docs/guides/contributing-components.md
@@ -3,7 +3,7 @@ title: Contributing Components
 sidebar_label: Contributing Components
 ---
 
-::: warn
+:::warning 
 
 This functionality is under development. With these docs, we aim to elicit feedback from our community (you!) and focus our development efforts. Currently, we do not offer support for 3rd party components, but we are working toward supporting this.
 

--- a/docs/docs/guides/contributing-components.md
+++ b/docs/docs/guides/contributing-components.md
@@ -9,9 +9,7 @@ This functionality is under development. With these docs, we aim to elicit feedb
 
 :::
 
-`Airy` is fundamentally a collection of components. When you [install `Airy`](../getting-started/installation/introduction.md), you get a few components out-of-the-box which form the infrastructure to install other components and begin using the platform.
-
-These core components are:
+Airy's functions are provided by components ready for _plug and play_. With every [installation of Airy](../getting-started/installation/introduction.md) we bundle a few default components to get started:
 
 1. airy-controller
 2. api-admin
@@ -20,7 +18,8 @@ These core components are:
 5. frontend-inbox
 6. frontend-control-center
 
-Airy's real value comes from the additional components you install through our marketplace in the Control Center UI of your Airy Instance. This documentation is on the processes we follow to create, update and store our components.
+Airy's real value comes from the additional components you install through our catalog in the Control Center UI of your Airy Instance. 
+In the following, we will explain how to create, update and store components.
 
 ## Components
 
@@ -28,11 +27,11 @@ import ComponentDefinition from '../getting-started/componentDefinition.mdx'
 
 <ComponentDefinition/>
 
-The Helm package and information on each components (except core components) are stored in an external repository managed by Airy called [airy-components](https://github.com/airyhq/airy-/airy-components). This repository is made up directories where each one contains the component's Helm package and information on it.
+The Helm package and information on each component (except core components) are stored in an external repository managed by Airy called [airy-components](https://github.com/airyhq/airy-/airy-components). This repository is made up of directories where each directory contains a component's Helm package and information.
 
 ## The Component File Structure
 
-Below is a model of the file stucture of a single component inside the [`airy-components`](https://github.com/airyhq/airy-/airy-components) repository.
+Below is a model of the file structure of a single component inside the [`airy-components`](https://github.com/airyhq/airy-components) repository.
 
 ```
 airy-components/

--- a/docs/docs/guides/contributing-components.md
+++ b/docs/docs/guides/contributing-components.md
@@ -18,7 +18,7 @@ Airy's functions are provided by components ready for _plug and play_. With ever
 5. frontend-inbox
 6. frontend-control-center
 
-Airy's real value comes from the additional components you install through our catalog in the Control Center UI of your Airy Instance. 
+Airy's real value comes from the additional components you install through our catalog in the Control Center UI of your Airy Instance.
 In the following, we will explain how to create, update and store components.
 
 ## Components

--- a/docs/docs/guides/contributing-components.md
+++ b/docs/docs/guides/contributing-components.md
@@ -15,7 +15,7 @@ import ComponentDefinition from '../getting-started/componentDefinition.mdx'
 
 <ComponentDefinition/>
 
-With every [installation of Airy](../getting-started/installation/introduction.md) we bundle a default components to get you started:
+With every [installation of Airy](../getting-started/installation/introduction.md) we bundle a set of default components to get you started:
 
 1. airy-controller
 2. api-admin
@@ -24,7 +24,7 @@ With every [installation of Airy](../getting-started/installation/introduction.m
 5. frontend-inbox
 6. frontend-control-center
 
-Airy also provides a marketplace of _plug and play_ components that extend the functionality of your Airy instance. You can install them through our catalog in the Control Center UI of your Airy Instance.
+Airy also provides a marketplace of _plug and play_ components that extend the functionality of your Airy instance. You can install them through the catalog page in the Control Center UI of your Airy Instance.
 
 In the following, we will explain how to create, update and store components.
 

--- a/docs/docs/guides/contributing-components.md
+++ b/docs/docs/guides/contributing-components.md
@@ -9,7 +9,7 @@ This functionality is under development. With these docs, we aim to elicit feedb
 
 :::
 
-`Airy Core` is fundamentally a collection of components. When you [install `Airy Core`](../getting-started/installation/introduction.md), you install a set of _core_ components which create the minimum infrastructure to install other components and begin using the platform.
+`Airy` is fundamentally a collection of components. When you [install `Airy`](../getting-started/installation/introduction.md), you get a few components out-of-the-box which form the infrastructure to install other components and begin using the platform.
 
 These core components are:
 
@@ -24,14 +24,9 @@ Airy's real value comes from the additional components you install through our m
 
 ## Components
 
-Airy is designed to support a plug-and-play architecture. Components are installed and run as pods in your cluster. Components can provide four kinds of functionality:
+import ComponentDefinition from '../getting-started/componentDefinition.mdx'
 
-1. Connector - i.e Rasa, DialogFlow
-2. Source - i.e., Facebook, WhatsApp, SMS
-3. API - i.e
-4. User Interface - i.e
-
-As a technical artifact, each component is a containerized application that is packaged and can be installed. We use Docker and Helm for this.
+<ComponentDefinition/>
 
 The Helm package and information on each components (except core components) are stored in an external repository managed by Airy called [airy-components](https://github.com/airyhq/airy-/airy-components). This repository is made up directories where each one contains the component's Helm package and information on it.
 
@@ -40,10 +35,11 @@ The Helm package and information on each components (except core components) are
 Below is a model of the file stucture of a single component inside the [`airy-components`](https://github.com/airyhq/airy-/airy-components) repository.
 
 ```
-/airy-components
-	/[COMPONENT_NAME]
-		information.yaml
-		/helm
+airy-components/
+└── [COMPONENT_NAME]/
+    ├── information.yaml
+    └── helm/
+        └── [HELM CHART]
 ```
 
 The `helm` directory contains all the files that make up the Helm package.

--- a/docs/docs/guides/contributing-connectors.md
+++ b/docs/docs/guides/contributing-connectors.md
@@ -1,0 +1,63 @@
+---
+title: Contributing Components
+sidebar_label: Contributing Components
+---
+
+::: warn
+
+This functionality is under development. With these docs, we aim to elicit feedback from our community (you!) and focus our development efforts. Currently, we do not offer support for 3rd party components, but we are working toward supporting this.
+
+:::
+
+`Airy Core` is fundamentally a collection of components. When you install Airy, you install a set of "Core" components which create the minimum infrastructure to install other components. These "core" components are:
+
+1. airy-controller
+2. api-admin
+3. api-communication
+4. api-websocket
+5. frontend-inbox
+6. frontend-control-center
+
+Airy's actual value comes from the additional components you can install through our marketplace in the Control Center UI. This documentation is on the processes we follow to create, update and store our components.
+
+## Components
+
+Airy is designed as plug-and-play architecture where components fit together in your cluster lego-blocks. Components can provide four kinds of functionality:
+
+1. Connector - i.e Rasa, DialogFlow - that [DEFINE]
+2. Source - i.e., Facebook, WhatsApp, SMS -
+3. API - i.e
+4. User Interface - i.e
+
+As a technical artifact, a component is a containerized application (we use Docker) packaged using Helm.
+
+The Helm charts and details about all components (except "Core" components) are stored in an external repository managed by Airy called [airy-/airy-components](https://github.com/airyhq/airy-/airy-components). Each directory represents a component.
+
+## Component File Structure
+
+Below is a model of a single component inside.
+
+```
+/airy-components
+	/[COMPONENT_NAME]
+		information.yaml
+		/helm
+```
+
+The `helm` directory contains the `values.yaml` file and all other templates/files needed to install the component onto a Kubernetes cluster using `helm`.
+
+The `information.yaml` contains the source-of-truth for the details of the component, including a description of its functionality, pricing, availability, and version. This file is written by the component maintainer and rendered into the UI of the Control Center.
+
+:::note
+
+Since all components are maintained by Airy, the versioning of every component will be tied to the version of Airy. However, once we support 3rd party components, we will revisit our versioning system.
+
+::::
+
+## Developing your own Components
+
+A step-by-step guide to creating your component!
+
+## Publishing your Component to the Airy Marketplace
+
+A step-by-step guide to make your component available to the world!

--- a/docs/docs/guides/contributing-connectors.md
+++ b/docs/docs/guides/contributing-connectors.md
@@ -9,7 +9,7 @@ This functionality is under development. With these docs, we aim to elicit feedb
 
 :::
 
-`Airy Core` is fundamentally a collection of components. When you install Airy, you install a set of "Core" components which create the minimum infrastructure to install other components. These "core" components are:
+`Airy Core` is fundamentally a collection of components. When you install `Airy Core`, you install a set of *core* components which create the minimum infrastructure to install other components and begin using the platform. These core components are:
 
 1. airy-controller
 2. api-admin
@@ -18,11 +18,11 @@ This functionality is under development. With these docs, we aim to elicit feedb
 5. frontend-inbox
 6. frontend-control-center
 
-Airy's actual value comes from the additional components you can install through our marketplace in the Control Center UI. This documentation is on the processes we follow to create, update and store our components.
+Airy's real value comes from the additional components you can install through our marketplace in the Control Center UI of your Airy Instance. This documentation is on the processes we follow to create, update and store our components.
 
 ## Components
 
-Airy is designed as plug-and-play architecture where components fit together in your cluster lego-blocks. Components can provide four kinds of functionality:
+Airy is designed to support a plug-and-play architecture. Components can be added like blocks in the cluster. Components can provide four kinds of functionality:
 
 1. Connector - i.e Rasa, DialogFlow - that [DEFINE]
 2. Source - i.e., Facebook, WhatsApp, SMS -
@@ -35,7 +35,7 @@ The Helm charts and details about all components (except "Core" components) are 
 
 ## Component File Structure
 
-Below is a model of a single component inside.
+Below is a model of the file stucture of a single component inside the `airy-components` repository.
 
 ```
 /airy-components
@@ -46,11 +46,11 @@ Below is a model of a single component inside.
 
 The `helm` directory contains the `values.yaml` file and all other templates/files needed to install the component onto a Kubernetes cluster using `helm`.
 
-The `information.yaml` contains the source-of-truth for the details of the component, including a description of its functionality, pricing, availability, and version. This file is written by the component maintainer and rendered into the UI of the Control Center.
+The `information.yaml` is the source-of-truth for every component. It includes a description of its functionality, pricing, availability, and version. This file is written by the component maintainer and rendered into the UI of the Control Center.
 
 :::note
 
-Since all components are maintained by Airy, the versioning of every component will be tied to the version of Airy. However, once we support 3rd party components, we will revisit our versioning system.
+Since all components are maintained by Airy, the versioning of every component is tied to the version of Airy. However, once we support 3rd party components, we will revisit our versioning system.
 
 ::::
 

--- a/docs/docs/guides/contributing-connectors.md
+++ b/docs/docs/guides/contributing-connectors.md
@@ -9,7 +9,7 @@ This functionality is under development. With these docs, we aim to elicit feedb
 
 :::
 
-`Airy Core` is fundamentally a collection of components. When you install `Airy Core`, you install a set of *core* components which create the minimum infrastructure to install other components and begin using the platform. These core components are:
+`Airy Core` is fundamentally a collection of components. When you install `Airy Core`, you install a set of _core_ components which create the minimum infrastructure to install other components and begin using the platform. These core components are:
 
 1. airy-controller
 2. api-admin

--- a/docs/docs/guides/contributing-to-airy.md
+++ b/docs/docs/guides/contributing-to-airy.md
@@ -1,6 +1,6 @@
 ---
-title: Contributing
-sidebar_label: Contributing
+title: Contributing to Airy
+sidebar_label: Contributing to Airy
 ---
 
 We ❤️ every form of contribution. The following document aims to provide enough

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -115,7 +115,8 @@ module.exports = {
     },
     {
       '📚 Guides': [
-        'guides/contributing',
+        'guides/contributing-to-airy',
+        'guides/contributing-components',
         'guides/analytics-demo',
         'guides/monitoring',
         'guides/backup',


### PR DESCRIPTION
The purpose of this PR is to organize discussions around how we want to maintain and update components. I have tried to capture our internal discussion on this issue in this initial draft. This PR also includes an update to our definition of `Components` in the glossary (#3294). Please amend/discuss/comment!

The secondary purpose is to merge these docs **before** we implement the proposed change. This way, we can adopt a "docs-driven" development approach.

The primary change proposed is the creation of an external repository where the Helm package and information on components are stored. The benefits of this approach are: 

1. We can update information on components between release cycles (if needed). 
2. The `description.yaml` associated with a connector file becomes the "source of truth" on components and can be standardized for the Control Center.
3. The helm files can help potential enterprise clients technically audit us.
4. We begin to create the infrastructure to support third-party components. 