### PR TITLE
[#3589] Retrieve installed components from cm

### DIFF
--- a/docs/docs/api/endpoints/components.md
+++ b/docs/docs/api/endpoints/components.md
@@ -35,7 +35,7 @@ The list of the currently configured components is returned.
 
 ## Update
 
-Update the configuration of a list of components. The `data` section is optional
+Update the configuration of a list of components. The endpoint can accept configuration for multiple components at once. In a case when the configuration for a particular component cannot be applied (for example the component is not fully installed), that component will be omitted and the request will still return a `200`. This component will also not be in the response. The `data` section is optional.
 
 `POST /components.update`
 

--- a/docs/docs/getting-started/components.md
+++ b/docs/docs/getting-started/components.md
@@ -79,6 +79,30 @@ Airy Core contains the following components:
 
 ## Installation
 
-For installation purposes Airy Core is packaged in a Helm chart which creates all the necessary Kubernetes resources. However, every component is an independent entity and can be installed or uninstalled separately. Every component is packaged in its own independent Helm chart and belongs to a `repository`. By default, the `airy-core` repository is added with the components that can be found under `infrastructure/helm-chart/charts/components/charts`.
+For installation purposes Airy Core is packaged in a Helm chart which creates all the necessary Kubernetes resources. However, every component is an independent entity and can be installed or uninstalled separately. Every component is packaged in its own independent Helm chart and belongs to a `repository`. By default, the `airy-core` repository is added with the components that can be found under https://helm.airy.co.
 
-Some components are installed by default, while others can be added or removed later, depending on the particular use case. Components can be managed through the `Control center` or through the [components](/api/endpoints/components) and [repositories](/api/endpoints/repositories) API endpoints.
+You can see all the available components either from the `Catalog` in the `Control center`. From the `Control center` you can also install, uninstall, configure, enable or disable the components.
+
+The following components are part of `Airy Core` and they cannot be uninstalled:
+
+- airy-controller
+- api-admin
+- communication
+- api-websocket
+- frontend-inbox
+- frontend-control-center
+
+Here is a list of the open source components which can be added to `Airy Core`:
+
+- api-contacts
+- integration-source-api
+- integration-webhook
+- media-resolver
+- sources-chatplugin
+- sources-facebook
+- sources-google
+- sources-twilio
+- sources-viber
+- sources-whatsapp
+
+More information about the components API can be found [here](/api/endpoints/components).

--- a/infrastructure/controller/pkg/endpoints/components_install_uninstall.go
+++ b/infrastructure/controller/pkg/endpoints/components_install_uninstall.go
@@ -46,6 +46,13 @@ func (s *ComponentsInstallUninstall) ServeHTTP(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	chart_version, err := s.getVersion(r.Context())
+	if err != nil {
+		klog.Error(err.Error())
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 	chartSpec := &helmCli.ChartSpec{
 		ReleaseName: releaseName,
 		ChartName:   chartName,
@@ -53,6 +60,7 @@ func (s *ComponentsInstallUninstall) ServeHTTP(w http.ResponseWriter, r *http.Re
 		UpgradeCRDs: true,
 		Replace:     true,
 		Force:       true,
+		Version:     chart_version,
 		ValuesYaml:  globals,
 	}
 
@@ -98,6 +106,23 @@ func (s *ComponentsInstallUninstall) getGlobals(ctx context.Context) (string, er
 	}
 
 	return globals, nil
+}
+
+func (s *ComponentsInstallUninstall) getVersion(ctx context.Context) (string, error) {
+	configMap, err := s.ClientSet.CoreV1().ConfigMaps(s.Namespace).Get(ctx, "core-config", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	var version string
+	if configMap.Data != nil {
+		version = configMap.Data["APP_IMAGE_TAG"]
+	}
+	if version == "" {
+		return "", fmt.Errorf("unable to retrieve version")
+	}
+
+	return version, nil
 }
 
 func getChartNameFromBlob(blob []byte) (string, string, error) {

--- a/infrastructure/controller/pkg/endpoints/components_install_uninstall.go
+++ b/infrastructure/controller/pkg/endpoints/components_install_uninstall.go
@@ -46,7 +46,7 @@ func (s *ComponentsInstallUninstall) ServeHTTP(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	chart_version, err := s.getVersion(r.Context())
+	chartVersion, err := s.getVersion(r.Context())
 	if err != nil {
 		klog.Error(err.Error())
 		w.WriteHeader(http.StatusInternalServerError)
@@ -60,7 +60,7 @@ func (s *ComponentsInstallUninstall) ServeHTTP(w http.ResponseWriter, r *http.Re
 		UpgradeCRDs: true,
 		Replace:     true,
 		Force:       true,
-		Version:     chart_version,
+		Version:     chartVersion,
 		ValuesYaml:  globals,
 	}
 

--- a/infrastructure/controller/pkg/endpoints/components_list.go
+++ b/infrastructure/controller/pkg/endpoints/components_list.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/airyhq/airy/infrastructure/controller/pkg/cache"
+	"github.com/airyhq/airy/lib/go/k8s"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/helm/cmd/helm/search"
 	"k8s.io/klog"
@@ -20,7 +21,7 @@ type ComponentsList struct {
 }
 
 func (s *ComponentsList) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	deployedCharts := s.DeployedCharts.GetDeployedCharts()
+	deployedCharts, err := k8s.GetInstalledComponents(r.Context(), s.Namespace, s.ClientSet)
 
 	components, err := getComponentsDetailsFromCloud()
 	if err != nil {

--- a/infrastructure/controller/pkg/endpoints/components_update.go
+++ b/infrastructure/controller/pkg/endpoints/components_update.go
@@ -39,7 +39,13 @@ func (s *ComponentsUpdate) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	responseComponents.Components = make(map[string]bool)
 
 	for _, component := range requestComponents.Components {
-		if !s.isComponentInstalled(component.Name) {
+		componentInstalled, err := s.isComponentInstalled(component.Name)
+		if err != nil {
+			klog.Error("Unable to retrieve the status of the component:" + component.Name + "\nError:\n" + err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if !componentInstalled {
 			klog.Error("Trying to apply configuration for a component that is not installed: " + component.Name)
 			continue
 		}
@@ -50,8 +56,8 @@ func (s *ComponentsUpdate) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		annotations := map[string]string{
 			"core.airy.co/enabled": strconv.FormatBool(component.Enabled),
 		}
-		applyErr := k8s.ApplyConfigMap(component.Name, s.namespace, payloads.ToCamelCase(component.Data), labels, annotations, s.clientSet, r.Context())
-		if applyErr != nil {
+		err = k8s.ApplyConfigMap(component.Name, s.namespace, payloads.ToCamelCase(component.Data), labels, annotations, s.clientSet, r.Context())
+		if err != nil {
 			klog.Error("Unable to apply configuration for component:" + component.Name + "\nError:\n" + err.Error())
 			responseComponents.Components[component.Name] = false
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -68,11 +74,11 @@ func (s *ComponentsUpdate) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 //NOTE: Prevent the upload of a configmap if the component is not present
-func (s *ComponentsUpdate) isComponentInstalled(configName string) bool {
+func (s *ComponentsUpdate) isComponentInstalled(configName string) (bool, error) {
 	deployedCharts, err := k8s.GetInstalledComponents(context.TODO(), s.namespace, s.clientSet)
 	if err != nil {
 		klog.Error("Unable to get installed components:\n" + err.Error())
-		return false
+		return false, err
 	}
-	return deployedCharts[configName]
+	return deployedCharts[configName], nil
 }

--- a/lib/go/k8s/configmaps.go
+++ b/lib/go/k8s/configmaps.go
@@ -73,6 +73,18 @@ func GetCmData(configmapName string, namespace string, clientset *kubernetes.Cli
 	return configMap.Data, nil
 }
 
+func GetInstalledComponents(ctx context.Context, namespace string, clientSet *kubernetes.Clientset) (map[string]bool, error) {
+	configmapList, err := clientSet.CoreV1().ConfigMaps(namespace).List(ctx, v1.ListOptions{LabelSelector: "core.airy.co/component"})
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get the ConfigMaps for the components. Error: %s\n", err)
+	}
+	components := make(map[string]bool)
+	for _, configmap := range configmapList.Items {
+		components[configmap.Name] = true
+	}
+	return components, nil
+}
+
 func GetComponentsConfigMaps(
 	ctx context.Context,
 	namespace string,


### PR DESCRIPTION
Instead of getting the installed helm charts and using the cache, I did a change where we fetch the installed components by retrieving the ConfigMaps which have the label `core.airy.co/component`.

With this change, I think that also the cache is not needed any more.

Resolves #3589.
Resolves #3599.