### PR TITLE
[#3758] Channels filter not appearing on the Inbox UI  

### DIFF
--- a/frontend/inbox/src/pages/Inbox/QuickFilter/Popup.tsx
+++ b/frontend/inbox/src/pages/Inbox/QuickFilter/Popup.tsx
@@ -18,13 +18,15 @@ import {useTranslation} from 'react-i18next';
 
 function mapStateToProps(state: StateModel) {
   const channels: Channel[] = Object.values(allChannels(state));
+  const conversations = Object.values(state.data.conversations.all.items);
+
   return {
     user: state.data.user,
     filter: state.data.conversations.filtered.currentFilter,
     tags: state.data.tags.all,
     channels,
-    sources: channels.reduce<Set<string>>((acc, {source}) => {
-      acc.add(source);
+    sources: conversations.reduce<Set<string>>((acc, {channel}) => {
+      acc.add(channel.source);
       return acc;
     }, new Set<string>()),
   };
@@ -46,6 +48,8 @@ const PopUpFilter = (props: PopUpFilterProps) => {
   const [channelSearch, setChannelSearch] = useState('');
   const [tagSearch, setTagSearch] = useState('');
   const {t} = useTranslation();
+
+  console.log('sources', sources);
 
   useEffect(() => {
     listTags();

--- a/frontend/inbox/src/pages/Inbox/QuickFilter/Popup.tsx
+++ b/frontend/inbox/src/pages/Inbox/QuickFilter/Popup.tsx
@@ -49,8 +49,6 @@ const PopUpFilter = (props: PopUpFilterProps) => {
   const [tagSearch, setTagSearch] = useState('');
   const {t} = useTranslation();
 
-  console.log('sources', sources);
-
   useEffect(() => {
     listTags();
   }, [listTags]);

--- a/frontend/inbox/src/reducers/data/channels/index.ts
+++ b/frontend/inbox/src/reducers/data/channels/index.ts
@@ -50,7 +50,7 @@ const channelsReducer = (state = {}, action: Action): ChannelsState => {
         },
       };
     case getType(actions.setCurrentChannelsAction):
-      return action.payload.reduce(setChannel, state);
+      return action.payload.reduce(setChannel, {});
     case getType(actions.addChannelsAction):
       return action.payload.reduce(setChannel, state);
     case getType(actions.setChannelAction):

--- a/frontend/inbox/src/reducers/data/channels/index.ts
+++ b/frontend/inbox/src/reducers/data/channels/index.ts
@@ -49,6 +49,8 @@ const channelsReducer = (state = {}, action: Action): ChannelsState => {
           metadata: merge({}, state[action.payload.identifier]?.metadata, action.payload.metadata),
         },
       };
+    case getType(actions.setCurrentChannelsAction):
+      return action.payload.reduce(setChannel, state);
     case getType(actions.addChannelsAction):
       return action.payload.reduce(setChannel, state);
     case getType(actions.setChannelAction):


### PR DESCRIPTION
closes #3758 

Changes: 
- Fixed the bug of channels & sources filters not appearing on the Inbox UI, which was related to this change #3636
- Improved experience by fixing the problem of not seeing sources which channels are disconnected in the filtering box (which results in a strange UX because disconnected channels appear in the Inbox)