### PR TITLE
[#3885] Whatsapp connector !config error

### DIFF
--- a/frontend/control-center/src/pages/Connectors/ChannelCard/index.module.scss
+++ b/frontend/control-center/src/pages/Connectors/ChannelCard/index.module.scss
@@ -52,7 +52,7 @@
   align-items: center;
   margin-bottom: 14px;
 
-  span {
+  p {
     color: var(--color-airy-blue);
     margin-right: 4px;
     text-decoration: underline;

--- a/frontend/control-center/src/pages/Connectors/ChannelCard/index.tsx
+++ b/frontend/control-center/src/pages/Connectors/ChannelCard/index.tsx
@@ -27,6 +27,19 @@ export const ChannelCard = (props: ChannelCardProps) => {
     componentInfo.isConfigured
   );
 
+  const configuredComponent = componentStatus !== ComponentStatus.notConfigured;
+
+  const ChannelsMention = () => {
+    return (
+      <>
+        <p>
+          {channelsToShow} {configuredComponent && channelsToShow === 1 ? t('channel') : t('channels')}
+        </p>
+        <ArrowRightIcon className={styles.arrowIcon} />
+      </>
+    );
+  };
+
   return (
     <div
       onClick={event => {
@@ -42,10 +55,7 @@ export const ChannelCard = (props: ChannelCardProps) => {
         </div>
         <div className={styles.linkContainer}>
           {componentStatus && <ConfigStatusButton componentStatus={componentStatus} configurationRoute={route} />}
-          <span>
-            {channelsToShow} {channelsToShow === 1 ? t('channel') : t('channels')}
-          </span>
-          <ArrowRightIcon className={styles.arrowIcon} />
+          {configuredComponent && <ChannelsMention />}
         </div>
       </div>
     </div>


### PR DESCRIPTION
closes #3885 

We agreed on this flow:
---> if a component is `not configured`, we do not show the connected channels (if the component has any)
--->  if a component is  `disabled` and `unhealthy` status: do we show the connected channels (because it means that the connector is configured and you can add channels)