### PR TITLE
Testing Whatsapp with debug logs

### DIFF
--- a/backend/components/whatsapp/connector/src/main/java/co/airy/core/sources/whatsapp/WebhookController.java
+++ b/backend/components/whatsapp/connector/src/main/java/co/airy/core/sources/whatsapp/WebhookController.java
@@ -59,9 +59,9 @@ public class WebhookController implements DisposableBean {
 
     @PostMapping("/whatsapp")
     ResponseEntity<Void> accept(@RequestBody String event, @RequestHeader("x-hub-signature") String signature) {
-        if (!isSignatureValid(event, signature)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
+        // if (!isSignatureValid(event, signature)) {
+        //     return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        // }
 
         String requestId = UUID.randomUUID().toString();
         try {

--- a/backend/components/whatsapp/connector/src/main/java/co/airy/core/sources/whatsapp/WebhookController.java
+++ b/backend/components/whatsapp/connector/src/main/java/co/airy/core/sources/whatsapp/WebhookController.java
@@ -59,9 +59,9 @@ public class WebhookController implements DisposableBean {
 
     @PostMapping("/whatsapp")
     ResponseEntity<Void> accept(@RequestBody String event, @RequestHeader("x-hub-signature") String signature) {
-        // if (!isSignatureValid(event, signature)) {
-        //     return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        // }
+        if (!isSignatureValid(event, signature)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
 
         String requestId = UUID.randomUUID().toString();
         try {

--- a/backend/components/whatsapp/connector/src/main/resources/application.properties
+++ b/backend/components/whatsapp/connector/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 thpool.core-pool-size=${REQUESTED_CPU}
 thpool.max-pool-size=${LIMIT_CPU}
 thpool.queue-capacity=${QUEUE_CAPACITY:0}
+logging.level.org.apache.kafka=DEBUG
+logging.level=DEBUG


### PR DESCRIPTION
After modifying the `application.properties` file, a new image needs to be pushed:

```
bazel run //backend/components/whatsapp/connector:release
bazel run //backend/components/whatsapp/events-router:release
```