### PR TITLE
Introduce Bazel Steward - a tool for keeping dependencies up to date

### DIFF
--- a/.github/workflows/bazel-steward.yaml
+++ b/.github/workflows/bazel-steward.yaml
@@ -1,0 +1,15 @@
+name: Bazel Steward
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * *'
+
+jobs:
+  bazel-steward:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: VirtusLab/bazel-steward@latest

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ airy_dev
 
 dist/
 bazel-*
+!bazel-steward.yaml
 
 # Emacs backup files
 .\#*

--- a/bazel-steward.yaml
+++ b/bazel-steward.yaml
@@ -1,0 +1,43 @@
+pull-requests:
+  - dependencies: "com.amazonaws:aws-java-sdk-*"
+    group-id: amazonaws
+  - dependencies: "com.fasterxml.jackson*:*"
+    group-id: jackson
+  - dependencies: "io.confluent:kafka-*"
+    group-id: confluent
+  - dependencies: "io.jsonwebtoken:jjwt-*"
+    group-id: jsonwebtoken
+  - dependencies: "org.apache.logging.log4j:log4j-*"
+    group-id: log4j
+  - dependencies: "org.slf4j:slf4j-*"
+    group-id: slf4j
+  - dependencies: "org.apache.avro:avro*"
+    group-id: avro
+  - dependencies: "org.apache.kafka:*"
+    group-id: kafka
+  - dependencies: "org.apache.lucene:lucene-*"
+    group-id: lucene
+  - dependencies: "org.hamcrest:*"
+    group-id: hamcrest
+  - dependencies: "org.junit.jupiter:junit-jupiter*"
+    group-id: jupiter
+  - dependencies: "org.mockito:mockito-*"
+    group-id: mockito
+  - dependencies: "org.springframework.boot:spring-boot-*"
+    group-id: spring-boot
+  - dependencies: "org.springframework:spring-*"
+    group-id: spring
+  - dependencies: "com.segment.analytics.java:*"
+    group-id: analytics
+  - dependencies: "io.github.openfeign:*"
+    group-id: openfeign
+  - limits:
+      max-open: 10
+
+post-update-hooks:
+  - kinds: maven
+    commands:
+      - "REPIN=1 bazel run @unpinned_maven//:pin"
+    files-to-commit:
+      - "maven_install.json"
+    run-for: commit


### PR DESCRIPTION
Hello everyone,

As one of developers I am submitting this pull request to introduce our new tool for Bazel repositories. [Bazel Steward](https://github.com/VirtusLab/bazel-steward) simplifies the process of checking and updating dependencies in your Bazel projects, making it more efficient to keep them up-to-date.
We hope that this tool will be useful to the Bazel community, and we look forward to your feedback.

This pull request integrates Bazel Steward through Github Actions which is currently the easiest way to do this. It will run every day at 12 and create new PRs or resolve conflicts on existing if necessary. You can preview how it looks in [a fork](https://github.com/lukaszwawrzyk/airy/pulls) that I used to test it. For more details, you can check [the project docs](https://virtuslab.github.io/bazel-steward/).

Bazel Steward is able to correctly update all your maven dependencies, Bazel rules and version of Bazel itself.

We hope that Bazel Steward will make it easier for you to manage dependencies. If you encounter any issues or have any feedback, please don't hesitate to reach out to us. Thank you!